### PR TITLE
fix(newsletter): le message "Il n'y a pas d'infolettres dans l'historique" n'apparaît que s'il y a un historique

### DIFF
--- a/src/components/NewsletterPage/NewsletterPage.tsx
+++ b/src/components/NewsletterPage/NewsletterPage.tsx
@@ -34,7 +34,7 @@ export default function NewsletterPage({
                     <h3>Historique des infolettres</h3>
                     <hr />
                     {newsletters.length == 0 && (
-                        <p>Il n'y a pas d'infolettres dans l'historique</p>
+                        <p>Il n'y a pas d'infolettre dans l'historique</p>
                     )}
                     <table className="sortable">
                         <tbody>

--- a/src/components/NewsletterPage/NewsletterPage.tsx
+++ b/src/components/NewsletterPage/NewsletterPage.tsx
@@ -33,7 +33,7 @@ export default function NewsletterPage({
                 <div className="panel panel-full-width">
                     <h3>Historique des infolettres</h3>
                     <hr />
-                    {newsletters.length && (
+                    {newsletters.length == 0 && (
                         <p>Il n'y a pas d'infolettres dans l'historique</p>
                     )}
                     <table className="sortable">


### PR DESCRIPTION
Il me semble que la condition est inversée (`newsletters.length && (<p>Il n'y a pas d'infolettres dans l'historique</p>)`) ce qui fait que le message apparaît systématiquement alors qu'il y a clairement un historique.

Je dois signaler que je n'ai pas pris le temps de tester le changement proposé en local.