### PR TITLE
feat: add talisman pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+if sh -c ': >/dev/tty' >/dev/null 2>/dev/null; then exec </dev/tty; yarn node-talisman --githook pre-commit -i; else yarn node-talisman --githook pre-commit; fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,7 @@
-if sh -c ': >/dev/tty' >/dev/null 2>/dev/null; then exec </dev/tty; yarn node-talisman --githook pre-commit -i; else yarn node-talisman --githook pre-commit; fi
+# ignore if using some GUI for GIT commits
+if sh -c ': >/dev/tty' >/dev/null 2>/dev/null; then
+  exec </dev/tty; 
+  yarn node-talisman --githook pre-commit -i;
+else 
+  yarn node-talisman --githook pre-commit;
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-# ignore if using some GUI for GIT commits
+# interactive only in shells
 if sh -c ': >/dev/tty' >/dev/null 2>/dev/null; then
   exec </dev/tty; 
   yarn node-talisman --githook pre-commit -i;

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,2 @@
+scopeconfig:
+  - scope: node

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "espace-membre",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@babel/plugin-proposal-private-methods": "^7.18.6",
         "@babel/preset-env": "^7.23.2",
@@ -89,9 +90,12 @@
         "dotenv": "^16.3.1",
         "eslint": "latest",
         "eslint-config-next": "latest",
+        "husky": "^9.0.10",
+        "is-ci": "^3.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "node-mocks-http": "^1.13.0",
+        "node-talisman": "^1.29.11",
         "postcss": "latest",
         "sass": "^1.68.0",
         "tailwindcss": "latest",
@@ -6610,6 +6614,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clogy": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/clogy/-/clogy-1.3.3.tgz",
+      "integrity": "sha512-qbRbt02HBBy5odvvfTvYrYtn9HtE782sDJpjIAjrlcSJFF1mND1+UZZUz43y3Wxkobn2kZJkxzvBDkZM+CJptA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
@@ -8445,6 +8458,12 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/exec-sh": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.6.tgz",
+      "integrity": "sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==",
+      "dev": true
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9707,6 +9726,21 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/husky": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.10.tgz",
+      "integrity": "sha512-TQGNknoiy6bURzIO77pPRu+XHi6zI7T93rX+QnJsoYFf3xdjKOur+IlfqzJGMHIK/wXrLg+GsvMs8Op7vI2jVA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/ical.js": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.5.0.tgz",
@@ -9976,6 +10010,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -14375,6 +14421,25 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+    },
+    "node_modules/node-talisman": {
+      "version": "1.29.11",
+      "resolved": "https://registry.npmjs.org/node-talisman/-/node-talisman-1.29.11.tgz",
+      "integrity": "sha512-zqpCrwamUpRcX90XeIwJNEr/wC6CzzFUMvH2wD1ts/KGfVboJEDIm4SI7/FfNOB7vCutadR2HsjMGdIfTUHf1w==",
+      "dev": true,
+      "dependencies": {
+        "clogy": "^1.3.3",
+        "exec-sh": "^0.3.4",
+        "mkdirp": "^1.0.4",
+        "request": "^2.88.2"
+      },
+      "bin": {
+        "node-talisman": "dist-node/index.bin.js"
+      },
+      "engines": {
+        "node": ">=12.14.x",
+        "npm": ">=6.13.x"
+      }
     },
     "node_modules/nodemailer": {
       "version": "6.9.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "NODE_ENV=test ts-mocha --paths -p tsconfig.json src/**/*.spec.ts __tests__/*.ts --exit --require ts-node/register --icu-data-dir=./node_modules/full-icu --require ./__tests__/env-setup.ts --timeout 30000",
     "seed": "knex seed:run --esm",
     "predev": "only-include-used-icons",
-    "prebuild": "only-include-used-icons"
+    "prebuild": "only-include-used-icons",
+    "postinstall": "is-ci || husky install"
   },
   "dependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",
@@ -99,9 +100,12 @@
     "dotenv": "^16.3.1",
     "eslint": "latest",
     "eslint-config-next": "latest",
+    "husky": "^9.0.10",
+    "is-ci": "^3.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "node-mocks-http": "^1.13.0",
+    "node-talisman": "^1.29.11",
     "postcss": "latest",
     "sass": "^1.68.0",
     "tailwindcss": "latest",


### PR DESCRIPTION
Ajout d'un precommit hook [talisman](https://github.com/thoughtworks/talisman) pour éviter un commit de secret.

Quand un nouveau secret est détecté lors du `git commit`, le CLI demandera confirmation d'ajouter ou pas la ligne suspecte à la whitelist (.talismanrc)