### PR TITLE
fix: prevent invalid exceptions

### DIFF
--- a/src/server/controllers/onboardingController/getConfirmation.ts
+++ b/src/server/controllers/onboardingController/getConfirmation.ts
@@ -6,7 +6,8 @@ export async function getConfirmation(req, res) {
         const { prNumber } = req.params;
         const { isEmailBetaAsked } = req.query;
         const prUrl = `https://github.com/${config.githubRepository}/pull/${prNumber}`;
-        res.render("onboardingSuccess", { prUrl, isEmailBetaAsked });
+        //res.render("onboardingSuccess", { prUrl, isEmailBetaAsked });
+        res.redirect("/");
     } catch (err) {
         console.error(err);
         Sentry.captureException(err);

--- a/src/server/controllers/onboardingController/postOnboardingForm.ts
+++ b/src/server/controllers/onboardingController/postOnboardingForm.ts
@@ -289,7 +289,7 @@ async function postOnboardingData(req, res, onSuccess, onError) {
         if (Object.keys(formValidationErrors).length) {
             req.flash(
                 "error",
-                "Un champs du formulaire est invalide ou manquant."
+                "Un champ du formulaire est invalide ou manquant."
             );
             throw new Error();
         }
@@ -383,7 +383,6 @@ async function postOnboardingData(req, res, onSuccess, onError) {
             prInfo,
         });
     } catch (err) {
-        Sentry.captureException(err);
         if (err instanceof Error) {
             req.flash("error", err.message);
         }


### PR DESCRIPTION
Le `render` etait invalide dans `getConfirmation` (plus de template)

et le `Sentry.captureException` semble inutile dans postOnboardingForm