### PR TITLE
fix(account): unescape author.role

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "sib-api-v3-sdk": "^8.5.0",
         "tss-react": "^4.9.4",
         "type-route": "^1.1.0",
+        "unescape": "^1.0.1",
         "uuid": "^9.0.1",
         "zod": "^3.22.4"
       },
@@ -8212,6 +8213,17 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -9405,6 +9417,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -17012,6 +17032,17 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/unescape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unescape/-/unescape-1.0.1.tgz",
+      "integrity": "sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "sib-api-v3-sdk": "^8.5.0",
     "tss-react": "^4.9.4",
     "type-route": "^1.1.0",
+    "unescape": "^1.0.1",
     "uuid": "^9.0.1",
     "zod": "^3.22.4"
   },

--- a/src/server/betagouv.ts
+++ b/src/server/betagouv.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import _ from "lodash";
 import ovh0 from "ovh";
+import unescape from "unescape";
 
 import { Incubator } from "@/models/incubator";
 import { Job, JobWTTJ } from "@/models/job";
@@ -82,7 +83,10 @@ const betaGouv = {
                             ? `${latestMission.status}/${latestMission.employer}`
                             : latestMission.employer;
                     }
-                    return author;
+                    return {
+                        ...author,
+                        role: unescape(author.role),
+                    };
                 })
             )
             .catch((err) => {


### PR DESCRIPTION
For some reason `author.role` is HTML encoded [in the API output](https://github.com/betagouv/beta.gouv.fr/blob/master/api/v2.6/authors.json#L9) which is called on some routes (ex: account home).

before:

<img width="565" alt="Capture d’écran 2024-03-28 à 22 19 41" src="https://github.com/betagouv/espace-membre-next/assets/124937/c11050dc-ae24-4eb1-aa39-856b4d8d1094">

after:

<img width="597" alt="Capture d’écran 2024-03-28 à 22 19 52" src="https://github.com/betagouv/espace-membre-next/assets/124937/9f25bbb4-cdf5-4e19-b9ae-93db9e3c65e8">

