### PR TITLE
fix: suppression de caractères en fin de ligne

### DIFF
--- a/src/server/views/templates/emails/onboardingReferent.ejs
+++ b/src/server/views/templates/emails/onboardingReferent.ejs
@@ -2,7 +2,7 @@ Hello <%= referent %>,
 
 **<%= name %> a besoin de toi pour obtenir son email @beta.gouv.fr**. Tu peux :
 
-- Approuver [sa fiche](<%= prUrl %>) (en cliquant sur "Squash and merge") si tu as un compte GitHub. d
+- Approuver [sa fiche](<%= prUrl %>) (en cliquant sur "Squash and merge") si tu as un compte GitHub.
 - Ou répondre à cet email pour confirmer que tu connais cette personne. Un membre de la communauté approuvera la demande.
 
 <% if (isEmailBetaAsked) { %>


### PR DESCRIPTION
Les caractères " d" en fin de ligne n'ont pas de sens.

Ce problème est visible sur Mattermost lorsque le bot envoie un message dans l'Espace Membre:

![Screenshot 2024-04-09 at 16-41-22 Espace Membre - Communauté beta gouv fr](https://github.com/betagouv/espace-membre-next/assets/1708780/e13435e4-077d-44a8-8431-7960dac9b077)

La coquille existe aussi sur le dépôt [secretariat](https://github.com/betagouv/secretariat) qui est moins actif donc je suppose que c'est le dépôt `espace-membre-next` qui est utilisé. Dans le cas contraire, il faut reporter la correction. Je peux le faire.