### PR TITLE
feat: add matomo info in memberpage

### DIFF
--- a/src/app/api/member/[username]/(matomo)/matomo-user/route.ts
+++ b/src/app/api/member/[username]/(matomo)/matomo-user/route.ts
@@ -1,0 +1,95 @@
+import { getServerSession } from "next-auth";
+
+import { matomoInfoDataSchema } from "@/models/matomoInfo";
+import db from "@/server/db";
+import { authOptions } from "@/utils/authoptions";
+
+const matomoUrl = `https://stats.beta.gouv.fr/`;
+const tokenAuth = process.env.MATOMO_TOKEN;
+
+const getUser = async (email) => {
+    const url = `${matomoUrl}?module=API&method=UsersManager.getUser&format=JSON&token_auth=${tokenAuth}&userLogin=${email}`;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error("Failed to fetch users");
+        }
+        const user = await response.json();
+        return user;
+    } catch (error) {
+        console.error("Error fetching users:", error);
+        return null;
+    }
+};
+
+const findUserByEmail = async (email) => {
+    const user = await getUser(email);
+    if (!user || user.result === "error") {
+        console.log("No users found or error fetching users");
+        return;
+    }
+    if (user) {
+        console.log("User Found:", user);
+    } else {
+        console.log("User not found");
+    }
+    return user;
+};
+
+export async function GET(
+    req: Request,
+    {
+        params: { username },
+    }: {
+        params: {
+            username: string;
+        };
+    }
+) {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user.id) {
+        throw new Error(`You don't have the right to access this function`);
+    }
+    if (!session.user.isAdmin) {
+        throw new Error(`User should be admin or should owned data`);
+    }
+
+    const dbUser = await db("users")
+        .where({
+            username,
+        })
+        .first();
+    const resp = {
+        primaryEmail: {},
+        secondaryEmail: {},
+    };
+    if (dbUser.primary_email) {
+        resp.primaryEmail = {
+            email: dbUser.primary_email,
+            events: [],
+            error: null,
+        };
+        try {
+            resp.primaryEmail = await findUserByEmail(dbUser.primary_email);
+        } catch (e) {
+            resp.primaryEmail["error"] = e;
+        }
+    }
+    if (dbUser.secondary_email) {
+        resp.secondaryEmail = {
+            email: dbUser.secondary_email,
+            events: [],
+            error: null,
+        };
+        try {
+            resp.secondaryEmail = await findUserByEmail(
+                "lucas.charrier" || dbUser.secondary_email
+            );
+        } catch (e) {
+            resp.secondaryEmail["error"] = e;
+        }
+    }
+    console.log("lcs matomo", resp);
+    return Response.json(matomoInfoDataSchema.parse(resp));
+}

--- a/src/components/MemberPage/MemberMatomo.tsx
+++ b/src/components/MemberPage/MemberMatomo.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from "react";
+
+import { fr } from "@codegouvfr/react-dsfr";
+import Accordion from "@codegouvfr/react-dsfr/Accordion";
+import { Table } from "@codegouvfr/react-dsfr/Table";
+import { format } from "date-fns";
+import { fr as frDateFns } from "date-fns/locale";
+
+import { EventActionFromDB, EventCodeToReadable } from "@/models/actionEvent";
+import {
+    matomoInfoDataSchema,
+    matomoInfoDataSchemaType,
+} from "@/models/matomoInfo";
+
+const MemberEventList = ({ userId }) => {
+    const [matomoInfo, setMatomoInfo] = useState<matomoInfoDataSchemaType>();
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchMatomoInfo = async () => {
+            if (!userId) return;
+
+            setLoading(true);
+            try {
+                const response = await fetch(
+                    `/api/member/${userId}/matomo-user`
+                );
+                console.log(response);
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+                const data = await response.json();
+                setMatomoInfo(matomoInfoDataSchema.parse(data));
+            } catch (error) {
+                console.error("Failed to fetch matomoInfo:", error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchMatomoInfo();
+    }, [userId]);
+    if (!matomoInfo?.primaryEmail && !matomoInfo?.secondaryEmail)
+        return <div>Pas d'information trouver sur un compte matomo</div>;
+    return (
+        <div>
+            {matomoInfo.primaryEmail && (
+                <li>
+                    Compte matomo avec {matomoInfo.primaryEmail.email}
+                    <br />
+                    2FA: {matomoInfo.primaryEmail.uses_2fa ? "true" : "false"}
+                </li>
+            )}
+            {matomoInfo.secondaryEmail && (
+                <li>
+                    Compte matomo avec {matomoInfo.secondaryEmail.email}
+                    <br />
+                    2FA: {matomoInfo.secondaryEmail.uses_2fa ? "true" : "false"}
+                </li>
+            )}
+        </div>
+    );
+};
+
+export default MemberEventList;

--- a/src/components/MemberPage/MemberPage.tsx
+++ b/src/components/MemberPage/MemberPage.tsx
@@ -16,6 +16,7 @@ import axios from "axios";
 import MemberBrevoEventList from "./MemberBrevoEventList";
 import MemberEmailServiceInfo from "./MemberEmailServiceInfo";
 import MemberEventList from "./MemberEventList";
+import MemberMatomo from "./MemberMatomo";
 import { EmailStatusCode } from "@/models/dbUser";
 import { EMAIL_STATUS_READABLE_FORMAT } from "@/models/misc";
 import routes, { computeRoute } from "@/routes/routes";
@@ -401,6 +402,7 @@ MemberPageProps) {
                     </>
                 )}
                 <MemberEmailServiceInfo userId={username} />
+                <MemberMatomo userId={username} />
                 {[
                     EmailStatusCode.EMAIL_CREATION_WAITING,
                     EmailStatusCode.EMAIL_VERIFICATION_WAITING,

--- a/src/models/matomoInfo.ts
+++ b/src/models/matomoInfo.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const matomoInfoSchema = z.object({
+    login: z.string(),
+    email: z.string().email(),
+    superuser_access: z.number().min(0).max(1), // Assuming this is a boolean flag stored as a number
+    date_registered: z.string().regex(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/),
+    invited_by: z.string(),
+    invite_expired_at: z.string().nullable(), // Assuming it can be either a datetime string or null
+    invite_accept_at: z.string().regex(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/),
+    last_seen: z.string().regex(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/),
+    invite_status: z.enum(["active", "expired", "pending"]), // Define the possible statuses as an enum
+    uses_2fa: z.boolean(),
+});
+
+export const matomoInfoDataSchema = z.object({
+    primaryEmail: matomoInfoSchema.optional(),
+    secondaryEmail: matomoInfoSchema.optional(),
+});
+
+export type matomoInfoDataSchemaType = z.infer<typeof matomoInfoDataSchema>;


### PR DESCRIPTION
Finalement, je pense que ce serait peut être mieux, d'utiliser une autre app, qui récupères les infos pour les membres et les mets en bdd. Ça permet d'avoir les tokens isolés sur une app qui écrit les infos nécessaires quelques part pour la rendre accessible. Si on réplique les calls api pour tous les services, espace-membre se retrouve avec beaucoup de token, ce n'est pas idéal.