### PR TITLE
fix(formations): sort by date ASC

### DIFF
--- a/src/components/Formation/FormationList.tsx
+++ b/src/components/Formation/FormationList.tsx
@@ -141,6 +141,11 @@ export default function FormationList({
               }, true);
           })
         : formations;
+    filteredFormations.sort((a, b) => {
+        return (
+            (a.start && b.start && a.start.getTime() - b.start.getTime()) || 0
+        );
+    });
     return (
         <div>
             <ul className="fr-tags-group fr-my-2w">


### PR DESCRIPTION
Ranger les formations dans l'ordre chronologique

![espace-membre-staging-pr201 osc-fr1 scalingo io_formations_filter=](https://github.com/betagouv/espace-membre-next/assets/124937/741dcb0e-1690-4b49-934b-627ae6f3b28b)
