### PR TITLE
fix(member): add warning+confirm when changing primary email

### DIFF
--- a/src/components/AccountPage/BlocConfigurerEmailPrincipal.tsx
+++ b/src/components/AccountPage/BlocConfigurerEmailPrincipal.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
+import { fr } from "@codegouvfr/react-dsfr";
+
 import axios from "axios";
 
 import { memberBaseInfoSchemaType } from "@/models/member";
@@ -27,35 +29,46 @@ export default function BlocConfigurerEmailPrincipal({
                 s'agit par défaut de {userInfos.username}@beta.gouv.fr.
                 <br />
                 <br />
-                En cas d'utilisation d'une adresse autre, l'email{" "}
-                {userInfos.username}
-                @beta.gouv.fr sera supprimé.
+                <i
+                    className={fr.cx("fr-icon--md", "fr-icon-warning-fill")}
+                />{" "}
+                En cas d'utilisation d'une adresse autre,{" "}
+                <strong>
+                    l'email {userInfos.username}
+                    @beta.gouv.fr sera définitivement supprimé
+                </strong>
+                .
             </p>
             {canChangeEmails && (
                 <form
                     method="POST"
                     onSubmit={(e) => {
                         e.preventDefault();
-                        setIsSaving(true);
-                        axios
-                            .put(
-                                computeRoute(
-                                    routes.USER_UPDATE_PRIMARY_EMAIL_API
-                                ).replace(":username", userInfos.username),
-                                {
-                                    primaryEmail: value,
-                                },
-                                {
-                                    withCredentials: true,
-                                }
-                            )
-                            .then((resp) => {
-                                setIsSaving(false);
-                            })
-                            .catch((err) => {
-                                setIsSaving(false);
-                                console.error(err);
-                            });
+                        const confirmed = confirm(
+                            "Êtes-vous vraiment certain(e) de vouloir changer cet email ?"
+                        );
+                        if (confirmed) {
+                            setIsSaving(true);
+                            axios
+                                .put(
+                                    computeRoute(
+                                        routes.USER_UPDATE_PRIMARY_EMAIL_API
+                                    ).replace(":username", userInfos.username),
+                                    {
+                                        primaryEmail: value,
+                                    },
+                                    {
+                                        withCredentials: true,
+                                    }
+                                )
+                                .then((resp) => {
+                                    setIsSaving(false);
+                                })
+                                .catch((err) => {
+                                    setIsSaving(false);
+                                    console.error(err);
+                                });
+                        }
                     }}
                 >
                     <Input


### PR DESCRIPTION
fix #318

Add warning + confirmation dialog when changing primary email

(Suite à une cata qui a couté pas mal de support)

Before:

<img width="727" alt="Capture d’écran 2024-07-17 à 10 16 32" src="https://github.com/user-attachments/assets/3995c62b-d91c-42b1-9b94-4b544555606e">

---

After:

(Clicks trigger a confirm dialog)

<img width="728" alt="Capture d’écran 2024-07-17 à 09 58 10" src="https://github.com/user-attachments/assets/14a93517-8e1e-4d1f-8532-8ffccd0151aa">
