### PR TITLE
fix(startup-form): disable h1 in product descriptions

### DIFF
--- a/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
+++ b/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useState } from "react";
 
 import { PluginComponent, DropList } from "react-markdown-editor-lite";
 
@@ -6,75 +7,63 @@ interface State {
     show: boolean;
 }
 
-export default class Header extends PluginComponent<State> {
+const Header2Plugin = (props) => {
+    const [visible, setVisible] = useState(false);
+    const show = () => {
+        setVisible(true);
+    };
+    const hide = () => {
+        setVisible(false);
+    };
+    const handleHeader = (header) => {
+        props.handleHeader(header);
+    };
+    return (
+        <span
+            className="button button-type-header"
+            title={"Header"}
+            onMouseEnter={show}
+            onMouseLeave={hide}
+        >
+            <i className={`rmel-iconfont rmel-icon-font-size`} />
+            {/* @ts-ignore todo */}
+            <DropList show={visible} onClose={hide}>
+                <ul className="header-list">
+                    <li className="list-item">
+                        <h2 onClick={() => handleHeader("h2")}>H2</h2>
+                    </li>
+                    <li className="list-item">
+                        <h3 onClick={() => handleHeader("h3")}>H3</h3>
+                    </li>
+                    <li className="list-item">
+                        <h4 onClick={() => handleHeader("h4")}>H4</h4>
+                    </li>
+                    <li className="list-item">
+                        <h5 onClick={() => handleHeader("h5")}>H5</h5>
+                    </li>
+                    <li className="list-item">
+                        <h6 onClick={() => handleHeader("h6")}>H6</h6>
+                    </li>
+                </ul>
+            </DropList>
+        </span>
+    );
+};
+
+export class Header extends PluginComponent<State> {
     static pluginName = "header2";
 
     constructor(props: any) {
         super(props);
-
-        this.show = this.show.bind(this);
-        this.hide = this.hide.bind(this);
-
-        this.state = {
-            show: false,
-        };
     }
 
-    private show() {
-        this.setState({
-            show: true,
-        });
-    }
-
-    private hide() {
-        this.setState({
-            show: false,
-        });
-    }
-    onSelectHeader?: (header: string) => void;
     handleHeader(header: string) {
         this.editor.insertMarkdown(header);
     }
 
     render() {
-        return (
-            <span
-                className="button button-type-header"
-                title={"Header"}
-                onMouseEnter={this.show}
-                onMouseLeave={this.hide}
-            >
-                <i className={`rmel-iconfont rmel-icon-font-size`} />
-                <DropList show={this.state.show} onClose={this.hide}>
-                    <ul className="header-list">
-                        <li className="list-item">
-                            <h2 onClick={this.handleHeader.bind(this, "h2")}>
-                                H2
-                            </h2>
-                        </li>
-                        <li className="list-item">
-                            <h3 onClick={this.handleHeader.bind(this, "h3")}>
-                                H3
-                            </h3>
-                        </li>
-                        <li className="list-item">
-                            <h4 onClick={this.handleHeader.bind(this, "h4")}>
-                                H4
-                            </h4>
-                        </li>
-                        <li className="list-item">
-                            <h5 onClick={this.handleHeader.bind(this, "h5")}>
-                                H5
-                            </h5>
-                        </li>
-                        <li className="list-item">
-                            <h6 onClick={this.handleHeader.bind(this, "h6")}>
-                                H6
-                            </h6>
-                        </li>
-                    </ul>
-                </DropList>
-            </span>
-        );
+        return <Header2Plugin handleHeader={this.handleHeader.bind(this)} />;
     }
 }
+
+export default Header;

--- a/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
+++ b/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
@@ -7,6 +7,7 @@ interface State {
     show: boolean;
 }
 
+// from https://github.com/HarryChen0506/react-markdown-editor-lite/blob/master/src/plugins/header/index.tsx
 const Header2Plugin = (props) => {
     const [visible, setVisible] = useState(false);
     const show = () => {

--- a/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
+++ b/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+
+import { PluginComponent, DropList } from "react-markdown-editor-lite";
+
+interface State {
+    show: boolean;
+}
+
+export default class Header extends PluginComponent<State> {
+    static pluginName = "header2";
+
+    constructor(props: any) {
+        super(props);
+
+        this.show = this.show.bind(this);
+        this.hide = this.hide.bind(this);
+
+        this.state = {
+            show: false,
+        };
+    }
+
+    private show() {
+        this.setState({
+            show: true,
+        });
+    }
+
+    private hide() {
+        this.setState({
+            show: false,
+        });
+    }
+    onSelectHeader?: (header: string) => void;
+    handleHeader(header: string) {
+        this.editor.insertMarkdown(header);
+    }
+
+    render() {
+        return (
+            <span
+                className="button button-type-header"
+                title={"Header"}
+                onMouseEnter={this.show}
+                onMouseLeave={this.hide}
+            >
+                <i className={`rmel-iconfont rmel-icon-font-size`} />
+                <DropList show={this.state.show} onClose={this.hide}>
+                    <ul className="header-list">
+                        <li className="list-item">
+                            <h2 onClick={this.handleHeader.bind(this, "h2")}>
+                                H2
+                            </h2>
+                        </li>
+                        <li className="list-item">
+                            <h3 onClick={this.handleHeader.bind(this, "h3")}>
+                                H3
+                            </h3>
+                        </li>
+                        <li className="list-item">
+                            <h4 onClick={this.handleHeader.bind(this, "h4")}>
+                                H4
+                            </h4>
+                        </li>
+                        <li className="list-item">
+                            <h5 onClick={this.handleHeader.bind(this, "h5")}>
+                                H5
+                            </h5>
+                        </li>
+                        <li className="list-item">
+                            <h6 onClick={this.handleHeader.bind(this, "h6")}>
+                                H6
+                            </h6>
+                        </li>
+                    </ul>
+                </DropList>
+            </span>
+        );
+    }
+}

--- a/src/components/StartupForm/StartupForm.tsx
+++ b/src/components/StartupForm/StartupForm.tsx
@@ -38,6 +38,10 @@ import {
     startupSchemaType,
 } from "@/models/startup";
 
+import MdEditorCustomHeaderPlugin from "./MdEditorCustomHeaderPlugin";
+
+MdEditor.use(MdEditorCustomHeaderPlugin);
+
 // import style manually
 const mdParser = new MarkdownIt(/* Markdown-it options */);
 
@@ -415,6 +419,27 @@ export function StartupForm(props: StartupFormProps) {
                                     height: "500px",
                                     marginTop: "0.5rem",
                                 }}
+                                plugins={[
+                                    "header2",
+                                    "font-bold",
+                                    "font-italic",
+                                    "font-underline",
+                                    "font-strikethrough",
+                                    "list-unordered",
+                                    "list-ordered",
+                                    "block-quote",
+                                    "block-wrap",
+                                    "block-code-inline",
+                                    "block-code-block",
+                                    "table",
+                                    "image",
+                                    "link",
+                                    "clear",
+                                    "logger",
+                                    "mode-toggle",
+                                    "full-screen",
+                                    "tab-insert",
+                                ]}
                                 renderHTML={(text) => mdParser.render(text)}
                                 onChange={(data, e) => {
                                     setValue("startup.description", data.text, {


### PR DESCRIPTION
disable les `h1` dans le formulaire d'édition fiche startup

fix #437

<img width="391" alt="Capture d’écran 2024-08-28 à 17 29 09" src="https://github.com/user-attachments/assets/f0c6204c-4bde-4489-9f99-855e04c08118">
