### PR TITLE
fix(create-member): adjust email wording

### DIFF
--- a/src/app/(private)/(dashboard)/community/create/CommunityCreateMemberPage.tsx
+++ b/src/app/(private)/(dashboard)/community/create/CommunityCreateMemberPage.tsx
@@ -232,7 +232,7 @@ export default function CommunityCreateMemberPage(props: BaseInfoUpdateProps) {
                                 >
                                     <Input
                                         label="Email (obligatoire)"
-                                        hintText="Vous recevrez sur cette adresse email les informations nécessaires pour créer votre compte @beta.gouv.fr. Elle servira également d'email secondaire."
+                                        hintText="Vous recevrez sur cette adresse email les informations nécessaires pour créer votre compte; elle servira également d'email secondaire. Si vous avez l'adresse mail d'une administration (ex : .gouv.fr) elle vous servira d'adresse de référence. Si ce n'est pas le cas, nous vous créerons une adresse mail @beta.gouv.fr"
                                         nativeInputProps={{
                                             placeholder:
                                                 "ex: grace.hopper@gmail.com",

--- a/src/app/(private)/(dashboard)/community/create/CommunityCreateMemberPage.tsx
+++ b/src/app/(private)/(dashboard)/community/create/CommunityCreateMemberPage.tsx
@@ -232,7 +232,7 @@ export default function CommunityCreateMemberPage(props: BaseInfoUpdateProps) {
                                 >
                                     <Input
                                         label="Email (obligatoire)"
-                                        hintText="Vous recevrez sur cette adresse email les informations nécessaires pour créer votre compte; elle servira également d'email secondaire. Si vous avez l'adresse mail d'une administration (ex : .gouv.fr) elle vous servira d'adresse de référence. Si ce n'est pas le cas, nous vous créerons une adresse mail @beta.gouv.fr"
+                                        hintText="Saisissez votre adresse email (celle de votre administration si vous en avez une ; votre email personnel sinon)."
                                         nativeInputProps={{
                                             placeholder:
                                                 "ex: grace.hopper@gmail.com",


### PR DESCRIPTION
Following @adenoix wording recos when creating a new member

<img width="459" alt="Capture d’écran 2024-10-04 à 12 06 41" src="https://github.com/user-attachments/assets/ac220e16-3cc2-4828-b081-4a8b1b67a957">
