### PR TITLE
Fix durationBetweenDate

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -16,8 +16,8 @@ export function durationBetweenDate(date1: Date, date2: Date) {
     if (duration.hours !== undefined) {
         result += `${duration.hours.toString()}h`;
     }
-    if (duration.seconds !== undefined && duration.seconds > 0) {
-        result += `${duration.seconds.toString().padStart(2, "0")}`;
+    if (duration.minutes !== undefined && duration.minutes > 0) {
+        result += `${duration.minutes.toString().padStart(2, "0")}`;
     }
     return result;
 }


### PR DESCRIPTION
La fonction durationBetweenDate affiche "1h" au lieu de "1h30" pour certaines formations. Je pense que c'est dû à une erreur entre minutes et secondes mais : 
- je n'ai pas pu tester en local, la page Formations ne s'affichait pas
- je n'ai pas trouvé de tests unitaires sur ce code

![image](https://github.com/user-attachments/assets/c9711e4b-5102-4e6c-8013-18dacecfff1d)
