### PR TITLE
feat(newsletter): update to use `publish_at` for scheduling publication

### DIFF
--- a/migrations/20241028170333_add_publish_at_column_to_newsletters.ts
+++ b/migrations/20241028170333_add_publish_at_column_to_newsletters.ts
@@ -1,0 +1,12 @@
+exports.up = function (knex) {
+    return knex.schema.table("newsletters", function (table) {
+        table.datetime("publish_at");
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.table("newsletters", function (table) {
+        // Drop the column if rolling back the migration
+        table.dropColumn("publish_at");
+    });
+};

--- a/src/@types/db.d.ts
+++ b/src/@types/db.d.ts
@@ -183,6 +183,7 @@ export interface Newsletters {
   brevo_url: string | null;
   created_at: Generated<Timestamp>;
   id: Generated<string>;
+  publish_at: Timestamp | null;
   sent_at: Timestamp | null;
   url: string;
   validator: string | null;

--- a/src/app/(private)/(dashboard)/admin/newsletters/page.tsx
+++ b/src/app/(private)/(dashboard)/admin/newsletters/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth/next";
+
+import { NewsletterForm } from "@/components/NewsletterForm/NewsletterForm";
+import { db } from "@/lib/kysely";
+import { newsletterToModel } from "@/models/mapper/newsletterMapper";
+import { authOptions } from "@/utils/authoptions";
+import { routeTitles } from "@/utils/routes/routeTitles";
+
+export const metadata: Metadata = {
+    title: `${routeTitles.adminMattermost()} / Espace Membre`,
+};
+
+export default async function Page(props) {
+    const session = await getServerSession(authOptions);
+
+    if (session && !session.user.isAdmin) {
+        redirect("/dashboard");
+    }
+
+    const dbNewsletter = await db
+        .selectFrom("newsletters")
+        .selectAll()
+        .where("sent_at", "is", null)
+        .executeTakeFirst();
+    if (!dbNewsletter) {
+        redirect("/dashboard");
+    }
+    const newsletter = newsletterToModel(dbNewsletter);
+    return <NewsletterForm newsletter={newsletter}></NewsletterForm>;
+}

--- a/src/app/(private)/(dashboard)/admin/newsletters/page.tsx
+++ b/src/app/(private)/(dashboard)/admin/newsletters/page.tsx
@@ -28,5 +28,5 @@ export default async function Page(props) {
         redirect("/dashboard");
     }
     const newsletter = newsletterToModel(dbNewsletter);
-    return <NewsletterForm newsletter={newsletter}></NewsletterForm>;
+    return <NewsletterForm newsletter={newsletter} />;
 }

--- a/src/app/(private)/(dashboard)/admin/page.tsx
+++ b/src/app/(private)/(dashboard)/admin/page.tsx
@@ -1,0 +1,49 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { Tile } from "@codegouvfr/react-dsfr/Tile";
+import school from "@gouvfr/dsfr/dist/artwork/pictograms/buildings/school.svg";
+import mailSend from "@gouvfr/dsfr/dist/artwork/pictograms/digital/mail-send.svg";
+import document from "@gouvfr/dsfr/dist/artwork/pictograms/document/document.svg";
+import community from "@gouvfr/dsfr/dist/artwork/pictograms/environment/human-cooperation.svg";
+import locationFrance from "@gouvfr/dsfr/dist/artwork/pictograms/map/location-france.svg";
+import { StaticImageData } from "next/image";
+
+import { SurveyBox } from "@/components/SurveyBox";
+import { linkRegistry } from "@/utils/routes/registry";
+
+export interface DashboardPageProps {
+    surveyCookieValue: string | null;
+}
+
+export default async function Page(props: DashboardPageProps) {
+    return (
+        <div className={fr.cx("fr-container", "fr-pb-6w")}>
+            <h2 className={fr.cx("fr-pt-4w")}>Admin</h2>
+            <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+                <div className={fr.cx("fr-col-12", "fr-col-lg-6")}>
+                    <Tile
+                        className={fr.cx("fr-tile--sm")}
+                        title="Mattermost"
+                        desc="Voir les membres mattermost"
+                        orientation="horizontal"
+                        imageUrl={(community as StaticImageData).src}
+                        linkProps={{
+                            href: "/admin/mattermost",
+                        }}
+                    />
+                </div>
+                <div className={fr.cx("fr-col-12", "fr-col-lg-6")}>
+                    <Tile
+                        className={fr.cx("fr-tile--sm")}
+                        title="Newsletters"
+                        desc="Definir la date de la prochaine newsletters"
+                        orientation="horizontal"
+                        imageUrl={(locationFrance as StaticImageData).src}
+                        linkProps={{
+                            href: `/admin/newsletters`,
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/(private)/(dashboard)/admin/page.tsx
+++ b/src/app/(private)/(dashboard)/admin/page.tsx
@@ -1,20 +1,10 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Tile } from "@codegouvfr/react-dsfr/Tile";
-import school from "@gouvfr/dsfr/dist/artwork/pictograms/buildings/school.svg";
-import mailSend from "@gouvfr/dsfr/dist/artwork/pictograms/digital/mail-send.svg";
-import document from "@gouvfr/dsfr/dist/artwork/pictograms/document/document.svg";
 import community from "@gouvfr/dsfr/dist/artwork/pictograms/environment/human-cooperation.svg";
 import locationFrance from "@gouvfr/dsfr/dist/artwork/pictograms/map/location-france.svg";
 import { StaticImageData } from "next/image";
 
-import { SurveyBox } from "@/components/SurveyBox";
-import { linkRegistry } from "@/utils/routes/registry";
-
-export interface DashboardPageProps {
-    surveyCookieValue: string | null;
-}
-
-export default async function Page(props: DashboardPageProps) {
+export default async function Page() {
     return (
         <div className={fr.cx("fr-container", "fr-pb-6w")}>
             <h2 className={fr.cx("fr-pt-4w")}>Admin</h2>

--- a/src/app/api/newsletters/actions.ts
+++ b/src/app/api/newsletters/actions.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { db } from "@/lib/kysely";
 import {
     newsletterInfoUpdateSchema,

--- a/src/app/api/newsletters/actions.ts
+++ b/src/app/api/newsletters/actions.ts
@@ -1,24 +1,44 @@
 "use server";
 
+import { getServerSession } from "next-auth";
+
 import { db } from "@/lib/kysely";
 import {
     newsletterInfoUpdateSchema,
     newsletterInfoUpdateSchemaType,
 } from "@/models/actions/newsletter";
+import { authOptions } from "@/utils/authoptions";
+import {
+    AuthorizationError,
+    ValidationError,
+    withErrorHandling,
+} from "@/utils/error";
 
 export const updateNewsletter = async (
     data: newsletterInfoUpdateSchemaType,
     newsletterId: string
 ) => {
-    const newsletterUpdatePayload = newsletterInfoUpdateSchema.parse(data);
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user.id) {
+        throw new AuthorizationError();
+    }
+    try {
+        newsletterInfoUpdateSchema.parse(data);
+    } catch (error) {
+        console.error("Database update failed:", error);
+        throw new ValidationError(
+            `Erreur de validation des données : ${error}`
+        );
+    }
 
     await db
         .updateTable("newsletters")
         .where("id", "=", newsletterId)
         .set({
-            ...newsletterUpdatePayload,
+            ...data,
         })
         .execute();
-
     return true;
 };
+
+export const safeUpdateNewsletter = withErrorHandling(updateNewsletter);

--- a/src/app/api/newsletters/actions.ts
+++ b/src/app/api/newsletters/actions.ts
@@ -1,0 +1,22 @@
+import { db } from "@/lib/kysely";
+import {
+    newsletterInfoUpdateSchema,
+    newsletterInfoUpdateSchemaType,
+} from "@/models/actions/newsletter";
+
+export const updateNewsletter = async (
+    data: newsletterInfoUpdateSchemaType,
+    newsletterId: string
+) => {
+    const newsletterUpdatePayload = newsletterInfoUpdateSchema.parse(data);
+
+    await db
+        .updateTable("newsletters")
+        .where("id", "=", newsletterId)
+        .set({
+            ...newsletterUpdatePayload,
+        })
+        .execute();
+
+    return true;
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -159,7 +159,7 @@ const MainHeader = () => {
     if (session?.user?.isAdmin) {
         nav.push({
             linkProps: {
-                href: "/admin/mattermost",
+                href: "/admin",
                 target: "_self",
             },
             text: "Admin",

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -1,18 +1,19 @@
 "use client";
-import React, { useCallback, useState } from "react";
+import React, { useEffect } from "react";
 
-import Alert from "@codegouvfr/react-dsfr/Alert";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import _ from "lodash";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 
 import { updateNewsletter } from "@/app/api/newsletters/actions";
 import {
     newsletterInfoUpdateSchema,
     newsletterInfoUpdateSchemaType,
 } from "@/models/actions/newsletter";
-import { Option } from "@/models/misc";
 import { newsletterSchemaType } from "@/models/newsletter";
 
 // data from secretariat API
@@ -72,6 +73,14 @@ export function NewsletterForm({ newsletter }: NewsletterFormProps) {
             });
     };
 
+    const publishAtValue = useWatch({
+        control,
+        name: `publish_at`,
+    });
+    const publishAtString = publishAtValue
+        ? new Date(publishAtValue).toISOString()
+        : "";
+
     return (
         <>
             <div>
@@ -98,6 +107,7 @@ export function NewsletterForm({ newsletter }: NewsletterFormProps) {
                 >
                     <Input
                         label={"url brevo de la newsletters"}
+                        nativeInputProps={{ ...register("brevo_url") }}
                         state={errors && errors.brevo_url ? "error" : "default"}
                         stateRelatedMessage={
                             errors && errors.brevo_url?.message
@@ -107,6 +117,12 @@ export function NewsletterForm({ newsletter }: NewsletterFormProps) {
                         label={"date de publication"}
                         nativeInputProps={{
                             type: "datetime-local",
+                            onChange: (e) => {
+                                setValue(
+                                    "publish_at",
+                                    new Date(e.target.value)
+                                );
+                            },
                         }}
                         state={
                             errors && errors.publish_at ? "error" : "default"
@@ -114,6 +130,19 @@ export function NewsletterForm({ newsletter }: NewsletterFormProps) {
                         stateRelatedMessage={
                             errors && errors.publish_at?.message
                         }
+                    />
+                    <Button
+                        className={fr.cx("fr-mt-3w")}
+                        disabled={isSaving}
+                        children={
+                            isSubmitting
+                                ? `Enregistrement en cours...`
+                                : `Enregistrer`
+                        }
+                        nativeButtonProps={{
+                            type: "submit",
+                            disabled: !isDirty || isSubmitting,
+                        }}
                     />
                 </form>
             </div>

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+import React, { useCallback, useState } from "react";
+
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { zodResolver } from "@hookform/resolvers/zod";
+import _ from "lodash";
+import { useForm } from "react-hook-form";
+
+import { updateNewsletter } from "@/app/api/newsletters/actions";
+import {
+    newsletterInfoUpdateSchema,
+    newsletterInfoUpdateSchemaType,
+} from "@/models/actions/newsletter";
+import { Option } from "@/models/misc";
+import { newsletterSchemaType } from "@/models/newsletter";
+
+// data from secretariat API
+export interface NewsletterFormProps {
+    newsletter: newsletterSchemaType;
+}
+
+export function NewsletterForm({ newsletter }: NewsletterFormProps) {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors, isDirty, isSubmitting, isValid },
+        setValue,
+        getValues,
+        watch,
+        control,
+    } = useForm<newsletterInfoUpdateSchemaType>({
+        resolver: zodResolver(newsletterInfoUpdateSchema),
+        mode: "onChange",
+        defaultValues: {},
+    });
+    const [alertMessage, setAlertMessage] = React.useState<{
+        title: string;
+        message: NonNullable<React.ReactNode>;
+        type: "success" | "warning";
+    } | null>();
+    const [isSaving, setIsSaving] = React.useState(false);
+
+    const onSubmit = (data: newsletterInfoUpdateSchemaType, e) => {
+        if (isSaving) {
+            return;
+        }
+        if (!isValid) {
+            return;
+        }
+        setIsSaving(true);
+        setAlertMessage(null);
+
+        updateNewsletter(data, newsletter.id)
+            .then((resp) => {
+                setIsSaving(false);
+                window.scrollTo({ top: 20, behavior: "smooth" });
+                setAlertMessage({
+                    title: `Mise à jour effectuée`,
+                    message: `La modification sera visible en ligne d'ici 24 heures.`,
+                    type: "success",
+                });
+            })
+            .catch((e: any) => {
+                setIsSaving(false);
+                window.scrollTo({ top: 20, behavior: "smooth" });
+                setAlertMessage({
+                    title: "Une erreur est survenue",
+                    message: e.message,
+                    type: "warning",
+                });
+            });
+    };
+
+    return (
+        <>
+            <div>
+                {!!alertMessage && (
+                    <Alert
+                        className="fr-mb-8v"
+                        severity={alertMessage.type}
+                        closable={false}
+                        title={alertMessage.title}
+                        description={
+                            alertMessage.message ? (
+                                <div
+                                    dangerouslySetInnerHTML={{
+                                        __html: alertMessage.message,
+                                    }}
+                                />
+                            ) : undefined
+                        }
+                    />
+                )}
+                <form
+                    onSubmit={handleSubmit(onSubmit)}
+                    aria-label="Modifier les informations du produit"
+                >
+                    <Input
+                        label={"url brevo de la newsletters"}
+                        state={errors && errors.brevo_url ? "error" : "default"}
+                        stateRelatedMessage={
+                            errors && errors.brevo_url?.message
+                        }
+                    />
+                    <Input
+                        label={"date de publication"}
+                        nativeInputProps={{
+                            type: "datetime-local",
+                        }}
+                        state={
+                            errors && errors.publish_at ? "error" : "default"
+                        }
+                        stateRelatedMessage={
+                            errors && errors.publish_at?.message
+                        }
+                    />
+                </form>
+            </div>
+        </>
+    );
+}

--- a/src/components/NewsletterForm/NewsletterForm.tsx
+++ b/src/components/NewsletterForm/NewsletterForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect } from "react";
+import React from "react";
 
 import { fr } from "@codegouvfr/react-dsfr";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
@@ -9,7 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import _ from "lodash";
 import { useForm, useWatch } from "react-hook-form";
 
-import { updateNewsletter } from "@/app/api/newsletters/actions";
+import { safeUpdateNewsletter } from "@/app/api/newsletters/actions";
 import {
     newsletterInfoUpdateSchema,
     newsletterInfoUpdateSchemaType,
@@ -52,7 +52,7 @@ export function NewsletterForm({ newsletter }: NewsletterFormProps) {
         setIsSaving(true);
         setAlertMessage(null);
 
-        updateNewsletter(data, newsletter.id)
+        safeUpdateNewsletter(data, newsletter.id)
             .then((resp) => {
                 setIsSaving(false);
                 window.scrollTo({ top: 20, behavior: "smooth" });
@@ -72,14 +72,6 @@ export function NewsletterForm({ newsletter }: NewsletterFormProps) {
                 });
             });
     };
-
-    const publishAtValue = useWatch({
-        control,
-        name: `publish_at`,
-    });
-    const publishAtString = publishAtValue
-        ? new Date(publishAtValue).toISOString()
-        : "";
 
     return (
         <>

--- a/src/components/NewsletterPage/NewsletterPage.tsx
+++ b/src/components/NewsletterPage/NewsletterPage.tsx
@@ -17,9 +17,14 @@ const formatNewsletterTitle = (newsletter) => {
     return newsletter.sent_at
         ? format(newsletter.sent_at, "d MMMM yyyy", { locale: fr })
         : format(
-              add(startOfWeek(newsletter.created_at, { weekStartsOn: 1 }), {
-                  weeks: 1,
-              }),
+              add(
+                  startOfWeek(newsletter.publish_at || newsletter.created_at, {
+                      weekStartsOn: 1,
+                  }),
+                  {
+                      weeks: 1,
+                  }
+              ),
               "d MMMM yyyy",
               { locale: fr }
           );
@@ -53,6 +58,15 @@ export default function NewsletterPage({
                             Infolettre de la semaine du{" "}
                             {formatNewsletterTitle(currentNewsletter)}
                         </h3>
+                        {currentNewsletter.publish_at && (
+                            <p>
+                                Cette infolettre sera publié le :{" "}
+                                {format(
+                                    currentNewsletter.publish_at,
+                                    "dd/MM/yyyy à HH:mm"
+                                )}
+                            </p>
+                        )}
                         <p>Lien de l'infolettre</p>
                         <a
                             href={

--- a/src/models/actions/newsletter.ts
+++ b/src/models/actions/newsletter.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+import { newsletterSchema } from "../newsletter";
+
+export const newsletterInfoUpdateSchema = z.object({
+    publish_at: newsletterSchema.shape.publish_at,
+    brevo_url: newsletterSchema.shape.brevo_url,
+});
+
+export type newsletterInfoUpdateSchemaType = z.infer<
+    typeof newsletterInfoUpdateSchema
+>;

--- a/src/models/mapper/newsletterMapper.ts
+++ b/src/models/mapper/newsletterMapper.ts
@@ -12,5 +12,6 @@ export const newsletterToModel = (
         id: newsletter.id,
         url: newsletter.url,
         brevo_url: newsletter.brevo_url,
+        publish_at: newsletter.publish_at,
     };
 };

--- a/src/models/newsletter.ts
+++ b/src/models/newsletter.ts
@@ -6,6 +6,7 @@ export const newsletterSchema = z.object({
     sent_at: z.date().nullable(),
     url: z.string().url(),
     brevo_url: z.string().nullable(),
+    publish_at: z.date().nullable().optional(),
 });
 
 export type newsletterSchemaType = z.infer<typeof newsletterSchema>;

--- a/src/server/schedulers/newsletterScheduler.ts
+++ b/src/server/schedulers/newsletterScheduler.ts
@@ -138,8 +138,8 @@ Vérifie une dernière fois le contenu du pad ${newsletter.url}. À 16 h, il ser
 };
 
 const REMINDER_NB_DAYS = {
-    FIRST_REMINDER: 6,
-    SECOND_REMINDER: 1,
+    FIRST_REMINDER: -6,
+    SECOND_REMINDER: -1,
     THIRD_REMINDER: 0,
 };
 

--- a/src/server/schedulers/newsletterScheduler.ts
+++ b/src/server/schedulers/newsletterScheduler.ts
@@ -5,6 +5,7 @@ import { format } from "date-fns/format";
 import { fr } from "date-fns/locale/fr";
 import { startOfWeek } from "date-fns/startOfWeek";
 import HedgedocApi from "hedgedoc-api";
+import { add } from 'date-fns';
 
 import BetaGouv from "../betagouv";
 import { db } from "@/lib/kysely";
@@ -79,10 +80,15 @@ const createNewsletter = async () => {
     );
     const padUrl = result.request.res.responseUrl;
     const message = `Nouveau pad pour l'infolettre : ${padUrl}`;
+
+const today = new Date();
+const dateIn14Days = add(today, { days: 14 });
     await db
         .insertInto("newsletters")
         .values({
             url: padUrl,
+            publish_at: const dateIn14Days = add(today, { days: 14 });
+
         })
         .execute();
     await sendInfoToChat({
@@ -133,6 +139,12 @@ Vérifie une dernière fois le contenu du pad ${newsletter.url}. À 16 h, il ser
     return message;
 };
 
+const REMINDER_NB_DAYS = {
+    FIRST_REMINDER: 7,
+    SECOND_REMINDER: 1,
+    THIRD_REMINDER: 0,
+};
+
 export async function newsletterReminder(reminder) {
     const currentNewsletter = await db
         .selectFrom("newsletters")
@@ -140,24 +152,15 @@ export async function newsletterReminder(reminder) {
         .where("sent_at", "is", null)
         .executeTakeFirst();
 
-    const lastSentNewsletter = await db
-        .selectFrom("newsletters")
-        .selectAll()
-        .orderBy("sent_at", "desc")
-        .where("sent_at", "is not", null)
-        .executeTakeFirst();
+    if (!currentNewsletter?.publish_at) {
+        // if publish_at is not defined, we do not send reminder
+        return;
+    }
 
-    if (lastSentNewsletter) {
-        const nbOfDays = differenceInDays(
-            new Date(),
-            lastSentNewsletter.sent_at!
-        );
-        if (nbOfDays < config.NEWSLETTER_NUMBER_OF_DAYS_WITH_LAST_NEWSLETTER) {
-            console.log(
-                `Will not sent newsletter : number of days between last newsletter ${nbOfDays}`
-            );
-            return;
-        }
+    const today = new Date();
+    const days = differenceInDays(today, currentNewsletter.publish_at);
+    if (REMINDER_NB_DAYS[reminder] !== days) {
+        return;
     }
 
     if (currentNewsletter) {
@@ -202,30 +205,22 @@ export { createNewsletter };
 export async function sendNewsletterAndCreateNewOne(
     shouldCreatedNewone = true
 ) {
-    const date = new Date();
     const currentNewsletter = await db
         .selectFrom("newsletters")
         .selectAll()
         .where("sent_at", "is", null)
-        .executeTakeFirst();
-    const lastSentNewsletter = await db
-        .selectFrom("newsletters")
-        .selectAll()
-        .orderBy("sent_at", "desc")
-        .where("sent_at", "is not", null)
-        .executeTakeFirst();
+        .executeTakeFirstOrThrow();
 
-    if (lastSentNewsletter) {
-        const nbOfDays = differenceInDays(
-            new Date(),
-            lastSentNewsletter.sent_at!
-        );
-        if (nbOfDays < config.NEWSLETTER_NUMBER_OF_DAYS_WITH_LAST_NEWSLETTER) {
-            return;
-        }
+    if (!currentNewsletter?.publish_at) {
+        // if publish_at is not defined, we do not send newsletter
+        return;
     }
 
-    if (currentNewsletter) {
+    const today = new Date();
+    if (
+        differenceInDays(today, currentNewsletter.publish_at) === 0 &&
+        today.getHours() === currentNewsletter.publish_at.getHours()
+    ) {
         if (config.FEATURE_SEND_NEWSLETTER || process.env.NODE_ENV === "test") {
             const pad = new HedgedocApi(
                 config.padEmail,
@@ -264,7 +259,7 @@ export async function sendNewsletterAndCreateNewOne(
             .updateTable("newsletters")
             .where("id", "=", currentNewsletter.id)
             .set({
-                sent_at: date,
+                sent_at: new Date(),
             })
             .execute();
         if (shouldCreatedNewone) {

--- a/src/server/schedulers/newsletterScheduler.ts
+++ b/src/server/schedulers/newsletterScheduler.ts
@@ -5,7 +5,6 @@ import { format } from "date-fns/format";
 import { fr } from "date-fns/locale/fr";
 import { startOfWeek } from "date-fns/startOfWeek";
 import HedgedocApi from "hedgedoc-api";
-import { add } from 'date-fns';
 
 import BetaGouv from "../betagouv";
 import { db } from "@/lib/kysely";
@@ -81,14 +80,13 @@ const createNewsletter = async () => {
     const padUrl = result.request.res.responseUrl;
     const message = `Nouveau pad pour l'infolettre : ${padUrl}`;
 
-const today = new Date();
-const dateIn14Days = add(today, { days: 14 });
+    const today = new Date();
+    const dateIn14Days = add(today, { days: 14 });
     await db
         .insertInto("newsletters")
         .values({
             url: padUrl,
-            publish_at: const dateIn14Days = add(today, { days: 14 });
-
+            publish_at: dateIn14Days,
         })
         .execute();
     await sendInfoToChat({
@@ -140,7 +138,7 @@ Vérifie une dernière fois le contenu du pad ${newsletter.url}. À 16 h, il ser
 };
 
 const REMINDER_NB_DAYS = {
-    FIRST_REMINDER: 7,
+    FIRST_REMINDER: 6,
     SECOND_REMINDER: 1,
     THIRD_REMINDER: 0,
 };


### PR DESCRIPTION
- Updated the newsletter logic to use the `publish_at` property as the reference for the publication date and time.
- Ensured that the `publish_at` field is now the primary field to determine when a newsletter will be published.
- This change improves clarity and consistency by explicitly defining the publication schedule using the `publish_at` property.