### PR TITLE
fix(member): always show primary_email status

### DIFF
--- a/src/components/MemberPage/Email/EmailContainer.tsx
+++ b/src/components/MemberPage/Email/EmailContainer.tsx
@@ -17,7 +17,6 @@ import BlocEmailResponder from "./BlocEmailResponder";
 import BlocRedirection from "./BlocRedirection";
 import { WebMailButton } from "./WebMailButton";
 import { MemberPageProps } from "../MemberPage";
-import { ToolTip } from "@/components/Tooltip";
 import frontConfig from "@/frontConfig";
 import {
     EmailInfos,
@@ -271,6 +270,20 @@ export default function EmailContainer({
                                     )
                                 )
                                 .otherwise(() => null)}
+                            {userInfos.primary_email_status !==
+                                EmailStatusCode.EMAIL_ACTIVE && (
+                                <Badge
+                                    severity="error"
+                                    small
+                                    className={fr.cx("fr-ml-1w")}
+                                >
+                                    {
+                                        EMAIL_STATUS_READABLE_FORMAT[
+                                            userInfos.primary_email_status
+                                        ]
+                                    }
+                                </Badge>
+                            )}
                         </span>
                         <br />
                     </>

--- a/src/components/MemberPage/MemberContact.tsx
+++ b/src/components/MemberPage/MemberContact.tsx
@@ -3,9 +3,12 @@ import { ReactNode } from "react";
 import Table from "@codegouvfr/react-dsfr/Table";
 import { fr } from "@codegouvfr/react-dsfr";
 import Badge from "@codegouvfr/react-dsfr/Badge";
+import { match } from "ts-pattern";
 
 import { MemberPageProps } from "./MemberPage";
 import { EMAIL_PLAN_TYPE } from "@/models/ovh";
+import { EMAIL_STATUS_READABLE_FORMAT } from "@/models/misc";
+import { EmailStatusCode } from "@/models/member";
 
 export const MemberContact = ({
     userInfos,
@@ -56,6 +59,20 @@ export const MemberContact = ({
                                 OVH MX
                             </Badge>
                         ) : null)}
+                    {userInfos.primary_email_status !==
+                        EmailStatusCode.EMAIL_ACTIVE && (
+                        <Badge
+                            severity="error"
+                            small
+                            className={fr.cx("fr-ml-1w")}
+                        >
+                            {
+                                EMAIL_STATUS_READABLE_FORMAT[
+                                    userInfos.primary_email_status
+                                ]
+                            }
+                        </Badge>
+                    )}
                 </>
             ),
         });


### PR DESCRIPTION
ensure we always show primary email status when incorrect in member card

fix #585