### PR TITLE
chore: add current newsletter edit button if user is admin

### DIFF
--- a/src/components/NewsletterPage/NewsletterPage.tsx
+++ b/src/components/NewsletterPage/NewsletterPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "@codegouvfr/react-dsfr/Button";
 import Table from "@codegouvfr/react-dsfr/Table";
 import { add } from "date-fns/add";
 import { format } from "date-fns/format";
@@ -15,20 +16,13 @@ export interface NewsletterPageProps {
 }
 
 const formatNewsletterTitle = (newsletter) => {
-    return newsletter.sent_at
-        ? format(newsletter.sent_at, "d MMMM yyyy", { locale: fr })
-        : format(
-              add(
-                  startOfWeek(newsletter.publish_at || newsletter.created_at, {
-                      weekStartsOn: 1,
-                  }),
-                  {
-                      weeks: 1,
-                  }
-              ),
-              "d MMMM yyyy",
-              { locale: fr }
-          );
+    return format(
+        newsletter.sent_at || newsletter.publish_at || newsletter.created_at,
+        "d MMMM yyyy",
+        {
+            locale: fr,
+        }
+    );
 };
 
 const formatNewsletter = (newsletter: newsletterSchemaType, isAdmin: boolean) =>
@@ -83,7 +77,18 @@ export default function NewsletterPage({
                                 )}
                             </p>
                         )}
-                        <p>Lien de l'infolettre</p>
+                        {session?.user.isAdmin && (
+                            <Button
+                                size="small"
+                                priority="secondary"
+                                linkProps={{ href: "/admin/newsletters" }}
+                            >
+                                Editer la date de publication
+                            </Button>
+                        )}
+                        <br />
+                        <br />
+                        <p>Lien de l'infolettre : </p>
                         <a
                             href={
                                 currentNewsletter.brevo_url ||
@@ -94,6 +99,7 @@ export default function NewsletterPage({
                             {currentNewsletter.brevo_url ||
                                 currentNewsletter.url}
                         </a>
+
                         <br />
                         <p>
                             L'infolettre est lue et partagée pendant l'hebdo


### PR DESCRIPTION
when a user has Admin access, he can edit the publish_at property of a newsletter. The link to the form to edit this value should appear in the interface.