### PR TITLE
feat: dupe member image as rewrited public route & revalidate

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,6 +36,12 @@ const nextConfig = {
             bodySizeLimit: "10mb",
         },
     },
+    rewrites: async () => [
+        {
+            source: "/api/public/member/:username/image",
+            destination: "/api/member/:username/image",
+        }
+    ],
     webpack: (config, { isServer }) => {
         if (!isServer) {
             // don't resolve 'fs' module on the client to prevent this error on build --> Error: Can't resolve 'fs'

--- a/src/app/api/member/[username]/image/route.ts
+++ b/src/app/api/member/[username]/image/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 
 import s3 from "@/lib/s3";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600; // 1 hour
 
 export const GET = async (
-    req: Request,
+    _: Request,
     { params: { username } }: { params: { username: string } }
 ) => {
     if (!username) {

--- a/src/components/BaseInfoUpdatePage/BaseInfoUpdate.tsx
+++ b/src/components/BaseInfoUpdatePage/BaseInfoUpdate.tsx
@@ -56,6 +56,7 @@ const postMemberData = async ({
             fileRelativeObjType: "member",
             fileObjIdentifier: username,
             fileType: "image/jpeg",
+            revalidateMemberImage: true,
         };
         const response = await fetch("/api/image", {
             method: "POST",
@@ -91,6 +92,7 @@ const postMemberData = async ({
                 fileRelativeObjType: "member",
                 fileObjIdentifier: username,
                 fileIdentifier: "avatar",
+                revalidateMemberImage: true,
             }),
         });
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -113,6 +113,6 @@ export const config = {
          * - favicon.ico, sitemap.xml, robots.txt (metadata files)
          */
         // "/dashboard",
-        "/((?!keskispasse|components|login|signin|api/hook|api/auth|static/|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+        "/((?!keskispasse|components|login|signin|api/hook|api/auth|api/public|static/|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
     ],
 };

--- a/src/models/actions/image.ts
+++ b/src/models/actions/image.ts
@@ -5,6 +5,7 @@ export const imagePostApiSchema = z.object({
     fileRelativeObjType: z.enum(["member", "startup", "incubator"]),
     fileObjIdentifier: z.string(),
     fileType: z.enum(["image/jpeg"]),
+    revalidateMemberImage: z.boolean().optional(),
 });
 
 export type imagePostApiSchemaType = z.infer<typeof imagePostApiSchema>;

--- a/src/server/config/jwt.config.ts
+++ b/src/server/config/jwt.config.ts
@@ -13,7 +13,7 @@ export const PUBLIC_ROUTES = [
     routes.ONBOARDING_ACTION,
     // /api\/auth\/*/,
     /api\/auth(?:\/|$)/,
-    /api\/public\/users\/*/,
+    /api\/public\/*/,
     /hook\/*/,
     /onboardingSuccess\/*/,
 ];


### PR DESCRIPTION
- add a rewrite rule for backward compatibility to have `/api/public/member/:username/image` as public route (pointing private `/api/member/:username/image`)
- filter out `api/public/` path in middleware
- remove "force-dynamic" from `/api/member/:username/image` and enable build-on-demand with revalidate feature (1h of cache)
- revalidate member only image after upload or delete on S3