### PR TITLE
feat: send email to startup members with information about members

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,18 +1,11 @@
 fileignoreconfig:
-- filename: __tests__/htmlbuilder.spec.ts
-  checksum: b5a1619df6d19ab4e1dfe36bcfeda327cfe85c52f077db82a5e0842230f94305
-- filename: src/server/views/templates/emails/memberValidationEmail/memberValidationEmail.tsx
-  checksum: 719ab0555ac1bae0adcfa7599a577f5b957f255be75f6b80f505694a4f2be2e5
-version: ""
-c59a9d1100346e12754ab4ee7d7c
 - filename: package-lock.json
-  checksum: add9168b63b1a9219558f2be2378591402a00d394be3bd9102715e43f8278e4f
-- filename: src/app/(private)/(dashboard)/admin/signaux-faibles-beta/AdminProductClientPage.tsx
+  checksum: e8ab779fc8fdbf1f46a33306b37387ce252f735b07469f0dbcd75a316a8f9599
+version: ""
+ock.json
   checksum: 9c740513497d70e871e4abcad3a9e509ef5b1a0da9db2d0d2d336c19854303b4
 - filename: src/app/(private)/(dashboard)/community/communes.json
   checksum: f69dbcbfe5e1e7c1bd9340c7bb3d9de9cbc9d4080363e80d8b4da190fb6ae045
-- filename: src/app/(private)/(dashboard)/dashboard/page.tsx
-  checksum: 7e4937c9492db99b0dedc48da2be20b8e122838cbf3fef6857e0d0d4717b2b3c
 - filename: src/app/(private)/(dashboard)/incubators/[id]/info-form/page.tsx
   checksum: 1ec9acf039a7d336e710ef7b47c385eb7080293ee2750c2cf99e9056cde7f129
 - filename: src/app/(private)/(dashboard)/services/matomo/page.tsx
@@ -34,7 +27,7 @@ c59a9d1100346e12754ab4ee7d7c
 - filename: src/components/CommunityPage/Community.tsx
   checksum: 50ed5a9ba8e03d4ffc248026cfae6fd6331c84c21b30aaa73c0bf30f22be9e2c
 - filename: src/components/Dashboard/DashboardPage.tsx
-  checksum: 38c58703d285c7cf19a6740c33166a0ebf7f270da1bfe3b1afc90ee760af0374
+  checksum: 75bfae226e0e1ef37d90f40938d0b2f73cc0ea554b7f69c4245f68179719f559
 - filename: src/components/IncubatorForm/IncubatorForm.tsx
   checksum: 267f0f0e491b06862cd957ae86d22baf799a705370673cd24e588391a4613a5a
 - filename: src/components/IncubatorPage/IncubatorPage.tsx
@@ -103,6 +96,8 @@ c59a9d1100346e12754ab4ee7d7c
   checksum: 598112766ea826e0c05c38962373358c520d8720ff8faebfbc65ea7f913fff44
 - filename: src/server/views/templates/emails/memberValidationEmail/memberValidationEmail.tsx
   checksum: d927d56d534024f2f271a955a467df69d7246646143ec80364dbc4fd3eacf380
+- filename: src/server/views/templates/emails/teamCompositionEmail/teamCompositionEmail.tsx
+  checksum: 8ec5495ed8db0f139a082bf0162e23cb05b0125b394abf63e447aca293dfcdbb
 - filename: src/utils/routes/list.ts
   checksum: ebb1c7a8c5fb51e0e49a23f79d1342f177946b4e783154bb265970b672aa2a2c
 - filename: src/utils/url.ts
@@ -110,12 +105,14 @@ c59a9d1100346e12754ab4ee7d7c
 scopeconfig:
 - scope: node
 version: "1.0"
-ls/member.ts
-      checksum: bd0f22c5efa62fd1388ac16c1ba321e393ede1e06d86f66d3561e556c098feb0
-    - filename: src/server/config/index.ts
-      checksum: a2591e8092f663b759ec49f7b51911e17af0f5f22de50b60340827e87755929a
-    - filename: src/server/queueing/workers/create-update-matomo-account.ts
-      checksum: 598112766ea826e0c05c38962373358c520d8720ff8faebfbc65ea7f913fff44
+name: src/utils/routes/list.ts
+      checksum: ebb1c7a8c5fb51e0e49a23f79d1342f177946b4e783154bb265970b672aa2a2c
+    - filename: src/utils/url.ts
+      checksum: 6c0989d85371d5071d9dcaa141e1c35b10f7124a3628deef443a4a1ccacfa34f
+    - filename: src/utils/routes/list.ts
+      checksum: ebb1c7a8c5fb51e0e49a23f79d1342f177946b4e783154bb265970b672aa2a2c
+    - filename: src/utils/url.ts
+      checksum: 21d2da1f85cc6ce2cc3324248e3c44ad84a6775f6c1cc8435e7cfa164824b853
     - filename: src/utils/routes/list.ts
       checksum: ebb1c7a8c5fb51e0e49a23f79d1342f177946b4e783154bb265970b672aa2a2c
     - filename: src/utils/url.ts

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Lorsqu'on utilise un autre domaine OVH (par exemple, un domain bac-à-sable pour
 
 Les tâches CRON sont gérées par une app scalingo dédiée via le [Procfile](./Procfile)
 
+La listes des cron sont dans les fichiers :
+./src/server/scheduler/cron.ts
+./src/server/queueing/schedule.ts
+
 ### Configuration de production
 
 | enabled | fréquence                                  | code                                                   | description                                                                                  |
@@ -154,3 +158,4 @@ Les tâches CRON sont gérées par une app scalingo dédiée via le [Procfile](.
 | ✅      | 10:00 am 1 th                              | sendMessageToActiveUsersWithoutSecondaryEmail          | Send message to active user without secondary email to update secondary email                |
 | ✅      | 15:00                                      | deleteMatomoAccount                                    | Delete matomo account                                                                        |
 | ✅      | 15:00                                      | deleteSentryAccount                                    | Delete sentry account                                                                        |
+| ✅      | 1st monday every 3 months                  | sendEmailToTeamsToCheckOnTeamComposition               | Send recap email to startups team every 3 months                                             |

--- a/__tests__/users.json
+++ b/__tests__/users.json
@@ -1,219 +1,219 @@
-[ 
-  {
-    "id": "membre.actif",
-    "fullname": "Membre Actif",
-    "github": "membre.actif",
-    "role": "Chargé de déploiement",
-    "domaine": "Développement",
-    "startups": ["test-startup"],
-    "missions": [
-      { 
-        "start": "2016-11-03",
-        "end": "2040-11-12",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "membre.expire",
-    "fullname": "Membre Expiré",
-    "github": "membre.expire",
-    "domaine": "Déploiement",
-    "missions": [
-      { 
-        "start": "2016-11-03",
-        "end": "2017-11-02",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "membre.parti",
-    "fullname": "Membre Parti",
-    "github": "test-github",
-    "domaine": "Animation",
-    "missions": [
-      { 
-        "start": "2016-11-03",
-        "end": "2050-10-30",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "membre.nouveau",
-    "fullname": "Membre Nouveau",
-    "domaine": "Animation",
-    "missions": [
-      { 
-        "start": "2020-07-03",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ],
-    "startups": ["test-startup"]
-  },
-  {
-    "id": "membre.plusieurs.missions",
-    "fullname": "Membre Plusieurs Missions",
-    "role": "Chargé de déploiement",
-    "domaine": "Coaching",
-    "missions": [
-      { 
-        "start": "2016-11-03",
-        "end": "2017-10-30",
-        "status": "independent",
-        "employer": "octo"
-      },
-      { 
-        "start": "2014-11-03",
-        "end": "2021-10-30",
-        "status": "admin",
-        "employer": "Département du Var"
-      }
-    ]
-  },
-  {
-    "id": "julien.dauphant",
-    "fullname": "Julien Dauphant",
-    "domaine": "Produit",
-    "missions": [
-      { 
-        "start": "2016-11-03",
-        "end": "2050-10-30",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "hela.ghariani",
-    "fullname": "Hela Ghariani",
-    "domaine": "Développement",
-    "missions": [
-      { 
-        "start": "2014-11-01",
-        "end": "2019-10-30",
-        "employer": "dinsic"
-      }
-    ]
-  },
-  {
-    "id": "nicolas.bouilleaud",
-    "fullname": "Nicolas Bouilleaud",
-    "domaine": "Autre",
-    "github": "n-b",
-    "missions": [
-      { 
-        "start": "2018-04-09",
-        "end": "2018-12-31",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "laurent.bossavit",
-    "fullname": "Laurent Bossavit",
-    "domaine": "Intraprenariat",
-    "missions": [
-      { 
-        "start": "2016-03-01",
-        "end": "2021-04-05",
-        "employer": "dinsic"
-      }
-    ]
-  },
-  {
-    "id": "stephane.legouffe",
-    "fullname": "Stéphane Legouffe",
-    "github": "slegouffe",
-    "domaine": "Design",
-    "missions": [
-      { 
-        "start": "2018-03-08",
-        "end": "2018-06-08",
-        "employer": "independent"
-      }
-    ]
-  },
-  {
-    "id": "sandra.chakroun",
-    "fullname": "Sandra Chakroun",
-    "domaine": "Design",
-    "missions": [
-      { 
-        "start": "2017-05-10",
-      "end": "2018-10-05",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "loup.wolff",
-    "fullname": "Loup Wolff",
-    "domaine": "Intraprenariat",
-    "missions": [
-      { 
-        "start": "2018-03-27",
-        "status": "admin",
-        "employer": "Ministère de la Culture"
-      }
-    ]
-  },
-  {
-    "id": "ishan.bhojwani",
-    "fullname": "Ishan Bhojwani",
-    "github": "IshanB",
-    "domaine": "Animation",
-    "missions": [
-      { 
-        "start": "2017-05-23",
-        "end": "2018-12-31",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "pierre.de_la_morinerie",
-    "fullname": "Pierre de La Morinerie",
-    "domaine": "Produit",
-    "missions": [
-      { 
-        "start": "2017-01-24",
-        "end": "2017-07-31",
-        "status": "independent",
-        "employer": "octo"
-      }
-    ]
-  },
-  {
-    "id": "thomas.guillet",
-    "fullname": "Thomas Guillet",
-    "domaine": "Coaching",
-    "missions": [
-      { 
-        "start": "2017-03-06",
-      "end": "2020-12-24",
-        "employer": "dinsic"
-      }
-    ]
-  },
-  {
-    "id": "mattermost.newuser",
-    "fullname": "Mattermost Newuser",
-    "domaine": "Déploiement",
-    "missions": [
-      { 
-        "start": "2021-07-09",
-        "end": "2050-12-24",
-        "employer": "dinsic"
-      }
-    ]
-  }
+[
+    {
+        "id": "membre.actif",
+        "fullname": "Membre Actif",
+        "github": "membre.actif",
+        "role": "Chargé de déploiement",
+        "domaine": "Développement",
+        "missions": [
+            {
+                "start": "2016-11-03",
+                "end": "2040-11-12",
+                "status": "independent",
+                "employer": "octo",
+                "startups": ["test-startup"]
+            }
+        ]
+    },
+    {
+        "id": "membre.expire",
+        "fullname": "Membre Expiré",
+        "github": "membre.expire",
+        "domaine": "Déploiement",
+        "missions": [
+            {
+                "start": "2016-11-03",
+                "end": "2017-11-02",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "membre.parti",
+        "fullname": "Membre Parti",
+        "github": "test-github",
+        "domaine": "Animation",
+        "missions": [
+            {
+                "start": "2016-11-03",
+                "end": "2050-10-30",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "membre.nouveau",
+        "fullname": "Membre Nouveau",
+        "domaine": "Animation",
+        "missions": [
+            {
+                "start": "2020-07-03",
+                "status": "independent",
+                "employer": "octo",
+                "startups": ["test-startup"]
+            }
+        ]
+    },
+    {
+        "id": "membre.plusieurs.missions",
+        "fullname": "Membre Plusieurs Missions",
+        "role": "Chargé de déploiement",
+        "domaine": "Coaching",
+        "missions": [
+            {
+                "start": "2016-11-03",
+                "end": "2017-10-30",
+                "status": "independent",
+                "employer": "octo"
+            },
+            {
+                "start": "2014-11-03",
+                "end": "2021-10-30",
+                "status": "admin",
+                "employer": "Département du Var"
+            }
+        ]
+    },
+    {
+        "id": "julien.dauphant",
+        "fullname": "Julien Dauphant",
+        "domaine": "Produit",
+        "missions": [
+            {
+                "start": "2016-11-03",
+                "end": "2050-10-30",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "hela.ghariani",
+        "fullname": "Hela Ghariani",
+        "domaine": "Développement",
+        "missions": [
+            {
+                "start": "2014-11-01",
+                "end": "2019-10-30",
+                "employer": "dinsic"
+            }
+        ]
+    },
+    {
+        "id": "nicolas.bouilleaud",
+        "fullname": "Nicolas Bouilleaud",
+        "domaine": "Autre",
+        "github": "n-b",
+        "missions": [
+            {
+                "start": "2018-04-09",
+                "end": "2018-12-31",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "laurent.bossavit",
+        "fullname": "Laurent Bossavit",
+        "domaine": "Intraprenariat",
+        "missions": [
+            {
+                "start": "2016-03-01",
+                "end": "2021-04-05",
+                "employer": "dinsic"
+            }
+        ]
+    },
+    {
+        "id": "stephane.legouffe",
+        "fullname": "Stéphane Legouffe",
+        "github": "slegouffe",
+        "domaine": "Design",
+        "missions": [
+            {
+                "start": "2018-03-08",
+                "end": "2018-06-08",
+                "employer": "independent"
+            }
+        ]
+    },
+    {
+        "id": "sandra.chakroun",
+        "fullname": "Sandra Chakroun",
+        "domaine": "Design",
+        "missions": [
+            {
+                "start": "2017-05-10",
+                "end": "2018-10-05",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "loup.wolff",
+        "fullname": "Loup Wolff",
+        "domaine": "Intraprenariat",
+        "missions": [
+            {
+                "start": "2018-03-27",
+                "status": "admin",
+                "employer": "Ministère de la Culture"
+            }
+        ]
+    },
+    {
+        "id": "ishan.bhojwani",
+        "fullname": "Ishan Bhojwani",
+        "github": "IshanB",
+        "domaine": "Animation",
+        "missions": [
+            {
+                "start": "2017-05-23",
+                "end": "2018-12-31",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "pierre.de_la_morinerie",
+        "fullname": "Pierre de La Morinerie",
+        "domaine": "Produit",
+        "missions": [
+            {
+                "start": "2017-01-24",
+                "end": "2017-07-31",
+                "status": "independent",
+                "employer": "octo"
+            }
+        ]
+    },
+    {
+        "id": "thomas.guillet",
+        "fullname": "Thomas Guillet",
+        "domaine": "Coaching",
+        "missions": [
+            {
+                "start": "2017-03-06",
+                "end": "2020-12-24",
+                "employer": "dinsic"
+            }
+        ]
+    },
+    {
+        "id": "mattermost.newuser",
+        "fullname": "Mattermost Newuser",
+        "domaine": "Déploiement",
+        "missions": [
+            {
+                "start": "2021-07-09",
+                "end": "2050-12-24",
+                "employer": "dinsic"
+            }
+        ]
+    }
 ]

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -217,7 +217,7 @@ const testUtils = {
                 start: string;
                 end?: string;
                 status?: string;
-                startups: (
+                startups?: (
                     | "a-startup-at-gip"
                     | "a-startup-at-dinum"
                     | "anotherstartup"
@@ -274,15 +274,26 @@ const testUtils = {
                             .values({
                                 ghid: startup,
                                 name: startup,
+                                mailing_list: `${startup}`,
                             })
                             .onConflict((oc) => {
                                 return oc.column("ghid").doUpdateSet({
                                     ghid: startup,
                                     name: startup,
+                                    mailing_list: `${startup}`,
                                 });
                             })
                             .returningAll()
                             .executeTakeFirstOrThrow();
+                        await db
+                            .insertInto("phases")
+                            .values({
+                                startup_id: insertedStartup.uuid,
+                                name: "acceleration",
+                                start: new Date(),
+                            })
+                            .onConflict((oc) => oc.doNothing())
+                            .execute();
                         await db
                             .insertInto("missions_startups")
                             .values({

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
                 "express-session": "^1.18.1",
                 "front-matter": "^4.0.2",
                 "hedgedoc-api": "github:betagouv/hedgedoc-api-lib-js#v1.0",
+                "html-to-text": "^9.0.5",
                 "ical.js": "^1.5.0",
                 "js-yaml": "^4.1.0",
                 "jsonwebtoken": "^9.0.2",
@@ -161,11 +162,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dependencies": {
-                "@babel/highlight": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -210,26 +212,27 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
+            "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
             "dependencies": {
-                "@babel/types": "^7.24.7",
+                "@babel/parser": "^7.26.9",
+                "@babel/types": "^7.26.9",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^2.5.1"
+                "jsesc": "^3.0.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+            "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -264,19 +267,17 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
-            "integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz",
+            "integrity": "sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-member-expression-to-functions": "^7.24.7",
-                "@babel/helper-optimise-call-expression": "^7.24.7",
-                "@babel/helper-replace-supers": "^7.24.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/helper-annotate-as-pure": "^7.25.9",
+                "@babel/helper-member-expression-to-functions": "^7.25.9",
+                "@babel/helper-optimise-call-expression": "^7.25.9",
+                "@babel/helper-replace-supers": "^7.26.5",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+                "@babel/traverse": "^7.26.9",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -323,6 +324,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
             "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.24.7"
             },
@@ -334,6 +336,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
             "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.24.7",
                 "@babel/types": "^7.24.7"
@@ -346,6 +349,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
             "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.24.7"
             },
@@ -354,40 +358,38 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
-            "integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+            "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-            "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-simple-access": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7"
+                "@babel/helper-module-imports": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/traverse": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -397,21 +399,21 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
-            "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+            "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -435,14 +437,14 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
-            "integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+            "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-member-expression-to-functions": "^7.24.7",
-                "@babel/helper-optimise-call-expression": "^7.24.7"
+                "@babel/helper-member-expression-to-functions": "^7.25.9",
+                "@babel/helper-optimise-call-expression": "^7.25.9",
+                "@babel/traverse": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -451,26 +453,14 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-            "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
-            "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+            "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.25.9",
+                "@babel/types": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -480,6 +470,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
             "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.24.7"
             },
@@ -488,25 +479,25 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-            "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -538,24 +529,13 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/highlight": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/parser": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+            "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+            "dependencies": {
+                "@babel/types": "^7.26.9"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -769,12 +749,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+            "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -886,12 +866,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-            "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+            "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1273,14 +1253,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
-            "integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+            "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-simple-access": "^7.24.7"
+                "@babel/helper-module-transforms": "^7.26.0",
+                "@babel/helper-plugin-utils": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1814,31 +1793,28 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+            "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/code-frame": "^7.26.2",
+                "@babel/parser": "^7.26.9",
+                "@babel/types": "^7.26.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
+            "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.7",
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-hoist-variables": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7",
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.9",
+                "@babel/parser": "^7.26.9",
+                "@babel/template": "^7.26.9",
+                "@babel/types": "^7.26.9",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -1847,13 +1823,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+            "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4632,6 +4607,18 @@
             "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==",
             "dev": true
         },
+        "node_modules/@selderee/plugin-htmlparser2": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+            "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+            "dependencies": {
+                "domhandler": "^5.0.3",
+                "selderee": "^0.11.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
+            }
+        },
         "node_modules/@sentry-internal/browser-utils": {
             "version": "8.32.0",
             "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.32.0.tgz",
@@ -5630,13 +5617,12 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "6.4.6",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.6.tgz",
-            "integrity": "sha512-8qpnGVincVDLEcQXWaHOf6zmlbwTKc6Us6PPu4CRnPXCzo2OGBS5cwgMMOWdxDpEz1mkbvXHpEy99M5Yvt682w==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
+            "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
             "dev": true,
             "dependencies": {
                 "@adobe/css-tools": "^4.4.0",
-                "@babel/runtime": "^7.9.2",
                 "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
                 "css.escape": "^1.5.1",
@@ -5648,30 +5634,6 @@
                 "node": ">=14",
                 "npm": ">=6",
                 "yarn": ">=1"
-            },
-            "peerDependencies": {
-                "@jest/globals": ">= 28",
-                "@types/bun": "latest",
-                "@types/jest": ">= 28",
-                "jest": ">= 28",
-                "vitest": ">= 0.32"
-            },
-            "peerDependenciesMeta": {
-                "@jest/globals": {
-                    "optional": true
-                },
-                "@types/bun": {
-                    "optional": true
-                },
-                "@types/jest": {
-                    "optional": true
-                },
-                "jest": {
-                    "optional": true
-                },
-                "vitest": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
@@ -6534,9 +6496,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.12.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6685,6 +6647,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -7271,13 +7234,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
-            "integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
+            "version": "0.10.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+            "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.1",
-                "core-js-compat": "^3.36.1"
+                "@babel/helper-define-polyfill-provider": "^0.6.2",
+                "core-js-compat": "^3.38.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -7670,6 +7633,17 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "peer": true
         },
+        "node_modules/browser-sync/node_modules/fs-extra": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+            "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
         "node_modules/browser-sync/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7677,6 +7651,15 @@
             "peer": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/browser-sync/node_modules/jsonfile": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+            "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
+            "peer": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/browser-sync/node_modules/supports-color": {
@@ -7691,10 +7674,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/browser-sync/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "peer": true,
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/browserslist": {
-            "version": "4.23.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-            "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7710,10 +7702,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001640",
-                "electron-to-chromium": "^1.4.820",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.1.0"
+                "caniuse-lite": "^1.0.30001688",
+                "electron-to-chromium": "^1.5.73",
+                "node-releases": "^2.0.19",
+                "update-browserslist-db": "^1.1.1"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -7844,9 +7836,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001641",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
-            "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
+            "version": "1.0.30001700",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+            "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7909,6 +7901,7 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -7922,6 +7915,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -8396,12 +8390,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.37.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
-            "integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
+            "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.23.0"
+                "browserslist": "^4.24.3"
             },
             "funding": {
                 "type": "opencollective",
@@ -8897,7 +8891,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9406,9 +9399,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.823",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.823.tgz",
-            "integrity": "sha512-4h+oPeAiGQOHFyUJOqpoEcPj/xxlicxBzOErVeYVMMmAiXUXsGpsFd0QXBMaUUbnD8hhSfLf9uw+MlsoIA7j5w=="
+            "version": "1.5.102",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
+            "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q=="
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -9748,9 +9741,9 @@
             "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "node_modules/escalade": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "engines": {
                 "node": ">=6"
             }
@@ -10772,16 +10765,16 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -11285,14 +11278,16 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-            "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
-            "peer": true,
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
             "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^3.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -11470,27 +11465,6 @@
                 "node": ">= 4.8.0"
             }
         },
-        "node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -11507,29 +11481,6 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "peer": true
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -11633,6 +11584,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -11800,6 +11752,21 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/html-to-text": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+            "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+            "dependencies": {
+                "@selderee/plugin-htmlparser2": "^0.11.0",
+                "deepmerge": "^4.3.1",
+                "dom-serializer": "^2.0.0",
+                "htmlparser2": "^8.0.2",
+                "selderee": "^0.11.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/htmlparser2": {
             "version": "8.0.2",
@@ -14896,14 +14863,14 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -14952,10 +14919,12 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-            "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
-            "peer": true,
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -15321,6 +15290,14 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/leac": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+            "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
             }
         },
         "node_modules/leaflet": {
@@ -16514,6 +16491,27 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/mocha/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -16976,9 +16974,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
         },
         "node_modules/node-talisman": {
             "version": "1.29.11",
@@ -17536,6 +17534,18 @@
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
+        "node_modules/parseley": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+            "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+            "dependencies": {
+                "leac": "^0.6.0",
+                "peberminta": "^0.9.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
+            }
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -17623,6 +17633,14 @@
             "dev": true,
             "dependencies": {
                 "through": "~2.3"
+            }
+        },
+        "node_modules/peberminta": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+            "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
             }
         },
         "node_modules/performance-now": {
@@ -17816,9 +17834,9 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -18140,9 +18158,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-            "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -19296,9 +19314,9 @@
             "integrity": "sha512-j05vL56tR90rsYqm9ZD05v6K4HI7t4yMDEvvU0x4f+IADXM9Jx1x9mzatxOs5drJq6dGhugxDW99mcPvXVLl+Q=="
         },
         "node_modules/sass": {
-            "version": "1.77.7",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.7.tgz",
-            "integrity": "sha512-9ywH75cO+rLjbrZ6en3Gp8qAMwPGBapFtlsMJoDTkcMU/bSe5a6cjKVUn5Jr4Gzg5GbP3HE8cm+02pLCgcoMow==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.0.tgz",
+            "integrity": "sha512-HKKIKf49Vkxlrav3F/w6qRuPcmImGVbIXJ2I3Kg0VMA+3Bav+8yE9G5XmP5lMj6nl4OlqbPftGAscNaNu28b8w==",
             "devOptional": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -19313,9 +19331,9 @@
             }
         },
         "node_modules/sass/node_modules/immutable": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-            "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+            "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
             "devOptional": true
         },
         "node_modules/sax": {
@@ -19370,6 +19388,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/selderee": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+            "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+            "dependencies": {
+                "parseley": "^0.12.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
             }
         },
         "node_modules/semver": {
@@ -20614,6 +20643,7 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -20930,14 +20960,6 @@
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -21670,12 +21692,11 @@
             "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
         },
         "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "peer": true,
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/unpipe": {
@@ -21709,42 +21730,10 @@
                 "node-int64": "^0.4.0"
             }
         },
-        "node_modules/unzipper/node_modules/fs-extra": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
-            }
-        },
-        "node_modules/unzipper/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/unzipper/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+            "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -21760,8 +21749,8 @@
                 }
             ],
             "dependencies": {
-                "escalade": "^3.1.2",
-                "picocolors": "^1.0.1"
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "express-session": "^1.18.1",
         "front-matter": "^4.0.2",
         "hedgedoc-api": "github:betagouv/hedgedoc-api-lib-js#v1.0",
+        "html-to-text": "^9.0.5",
         "ical.js": "^1.5.0",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",

--- a/src/components/emails/layouts/StandardEmail.tsx
+++ b/src/components/emails/layouts/StandardEmail.tsx
@@ -1,0 +1,178 @@
+import { PropsWithChildren } from "react";
+
+import {
+    Mjml,
+    MjmlAll,
+    MjmlAttributes,
+    MjmlBody,
+    MjmlButton,
+    MjmlColumn,
+    MjmlDivider,
+    MjmlGroup,
+    MjmlHead,
+    MjmlImage,
+    MjmlSection,
+    MjmlStyle,
+    MjmlText,
+    MjmlTitle,
+    MjmlWrapper,
+} from "@luma-team/mjml-react";
+
+import { getBaseUrl } from "@/utils/url";
+
+export interface StandardLayoutProps {
+    title: string;
+}
+
+export function StandardLayout(props: PropsWithChildren<StandardLayoutProps>) {
+    const currentYear = new Date().getFullYear();
+
+    return (
+        <Mjml>
+            <MjmlHead>
+                <MjmlTitle>{props.title}</MjmlTitle>
+                {/* TODO: the preview can be interesting but it would add transpiling the context one more time and convert the html to plaintext to keep only the first valuable line (not the "Hello Thomas,"...) (ref: https://www.litmus.com/blog/the-ultimate-guide-to-preview-text-support) */}
+                {/* <MjmlPreview>{props.title}</MjmlPreview> */}
+                <MjmlAttributes>
+                    <MjmlSection padding="10px 0px"></MjmlSection>
+                    <MjmlColumn padding="0px 0px"></MjmlColumn>
+                    <MjmlDivider
+                        css-class="divider"
+                        border-width="1px"
+                        border-color="#000000"
+                    ></MjmlDivider>
+                    <MjmlAll fontFamily='"Marianne", arial, sans-serif'></MjmlAll>
+                    <MjmlText
+                        cssClass="light-text"
+                        color="#3a3a3a"
+                        fontSize="14px"
+                        lineHeight="24px"
+                    ></MjmlText>
+                    <MjmlButton
+                        backgroundColor="#000091"
+                        borderRadius="0px"
+                        cssClass="light-button"
+                        color="#f5f5fe"
+                        fontSize={16}
+                        fontWeight={400}
+                        lineHeight="24px"
+                        padding="8px 16px"
+                    ></MjmlButton>
+                </MjmlAttributes>
+                <MjmlStyle>
+                    {`hr {
+                        color: #000000; // Otherwise it's grey
+                        }
+
+                        th {
+                        background: none !important; // Prevent the heading column/row to have a color
+                        }
+
+                        a {
+                        color: #000091;
+                        text-underline-offset: 3px;
+                        }
+
+                        h1,
+                        h2 {
+                        // Bigger headings were rendering all tight on multiple lines
+                        line-height: 1.2em;
+                        }
+
+                        // dsfr hr
+                        .fr-hr-or {
+                            font-size: .875rem;
+                            line-height: 1.5rem;
+                            text-transform: uppercase;
+                            font-weight: 700;
+                            display: flex;
+                            flex-direction: row;
+                            align-items: center;
+                            justify-content: center;
+                            flex-wrap: nowrap;
+                        }
+
+                        .fr-hr-or:after,.fr-hr-or:before {
+                            content: "";
+                            display: inline-flex;
+                            height: 1px;
+                            width: 40%;
+                            background-color: #000000;
+                            --idle: transparent;
+                            --hover: #000000;
+                            --active: #000000;
+                        }
+
+                        .fr-hr-or:before {
+                            margin-right: .75rem
+                        }
+
+                        .fr-hr-or:after {
+                            margin-left: .75rem
+                        }
+
+                        .member-info th, .member-info td {
+                        border: 1px solid #000;
+                        padding: 10px;
+                        }`}
+                </MjmlStyle>
+            </MjmlHead>
+            <MjmlBody width={500}>
+                <MjmlWrapper cssClass={`light-body`}>
+                    <MjmlSection>
+                        <MjmlGroup>
+                            <MjmlColumn
+                                cssClass="logo-section"
+                                verticalAlign="middle"
+                                width="24%"
+                            >
+                                {/* `MjmlColumn` width must be a percentage (ref: https://github.com/mjmlio/mjml/issues/2489) */}
+                                {/* TODO: upload images on our own CDN, or use public folder of the app... */}
+                                <MjmlImage
+                                    src={`${getBaseUrl()}/static/images/home-illustration.png`}
+                                    alt="logo"
+                                    paddingRight={0}
+                                />
+                            </MjmlColumn>
+                            <MjmlColumn verticalAlign="middle" width="76%">
+                                <MjmlText
+                                    fontSize={20}
+                                    fontWeight={700}
+                                    paddingBottom={2}
+                                >
+                                    Espace-membre beta.gouv.fr
+                                </MjmlText>
+                                <MjmlText fontSize={16} paddingTop={2}>
+                                    Communauté beta.gouv.fr
+                                </MjmlText>
+                            </MjmlColumn>
+                        </MjmlGroup>
+                    </MjmlSection>
+                    <MjmlSection
+                        cssClass="light-main-section"
+                        backgroundColor="#f6f6f6"
+                    >
+                        <MjmlGroup>
+                            <MjmlColumn>{props.children}</MjmlColumn>
+                        </MjmlGroup>
+                    </MjmlSection>
+                    <MjmlSection>
+                        <MjmlGroup>
+                            <MjmlColumn>
+                                <MjmlText
+                                    align="center"
+                                    color="#666666"
+                                    fontSize={12}
+                                    paddingTop={2}
+                                    paddingBottom={0}
+                                >
+                                    {currentYear} © Espace-Membre
+                                </MjmlText>
+                            </MjmlColumn>
+                        </MjmlGroup>
+                    </MjmlSection>
+                </MjmlWrapper>
+            </MjmlBody>
+        </Mjml>
+    );
+}

--- a/src/lib/kysely/queries/search.ts
+++ b/src/lib/kysely/queries/search.ts
@@ -4,7 +4,6 @@ import { MEMBER_PROTECTED_INFO } from "./users";
 import { DB, StartupsPhaseEnum, UsersDomaineEnum } from "@/@types/db"; // generated with `npm run kysely-codegen`
 import { db as database } from "@/lib/kysely";
 
-
 // get list of startups with latest phase
 export const getSesWithLatestPhaseQuery = (db: Kysely<DB> = database) =>
     db

--- a/src/lib/kysely/queries/users.ts
+++ b/src/lib/kysely/queries/users.ts
@@ -2,6 +2,7 @@ import { isAfter } from "date-fns/isAfter";
 import { isBefore } from "date-fns/isBefore";
 import { sql, ExpressionBuilder, Kysely, SelectExpression } from "kysely";
 import { UpdateObjectExpression } from "kysely/dist/cjs/parser/update-set-parser";
+import _ from "lodash";
 
 import { DB } from "@/@types/db"; // generated with `npm run kysely-codegen`
 import { db as database, jsonArrayFrom } from "@/lib/kysely";
@@ -45,7 +46,7 @@ export async function getUserInfos(
     let query = db
         .selectFrom("users")
         .selectAll("users")
-        .select((eb) => [withEndDate, withMissions]);
+        .select((eb) => [withEndDate, withMissions, withTeams]);
     if ("username" in params) {
         query = query.where("users.username", "=", params.username);
     } else {
@@ -61,32 +62,37 @@ export async function getUserByStartup(
     startupUuid: string,
     db: Kysely<DB> = database
 ) {
-    return db
-        .selectFrom("users")
-        .select((eb) => [
-            ...MEMBER_PROTECTED_INFO,
-            withMissions(eb),
-            withTeams(eb),
-        ])
+    return protectedDataSelect(db)
+        .select((eb) => [withMissions(eb), withTeams(eb)])
         .leftJoin("missions", "missions.user_id", "users.uuid")
         .leftJoin("missions_startups", "missions.uuid", "mission_id")
         .where("missions_startups.startup_id", "=", startupUuid)
-        .groupBy(MEMBER_PROTECTED_INFO)
         .execute();
 }
 
+export async function getUsersByStartupIds(
+    startupUuids: string[],
+    db: Kysely<DB> = database
+) {
+    const data = await protectedDataSelect(db)
+        .select((eb) => [withMissions(eb), withTeams(eb)])
+        .leftJoin("missions", "missions.user_id", "users.uuid")
+        .leftJoin("missions_startups", "missions.uuid", "mission_id")
+        .select("startup_id")
+        .where("missions_startups.startup_id", "in", startupUuids)
+        .execute();
+    const grouped = _.groupBy(data, "startup_id");
+    return grouped;
+}
 /** Return member informations */
 export async function getUserBasicInfo(
     params: { username: string } | { uuid: string },
     db: Kysely<DB> = database
 ) {
-    let query = db
-        .selectFrom("users")
-        .select((eb) => [
-            ...MEMBER_PROTECTED_INFO,
-            withMissions(eb),
-            withTeams(eb),
-        ]);
+    let query = protectedDataSelect(db).select((eb) => [
+        withMissions(eb),
+        withTeams(eb),
+    ]);
 
     if ("username" in params) {
         query = query.where("users.username", "=", params.username);
@@ -107,7 +113,11 @@ export const getAllUsersInfoQuery = (db: Kysely<DB> = database) =>
 
 /** Return member informations */
 export async function getAllUsersInfo(db: Kysely<DB> = database) {
-    const query = getAllUsersInfoQuery(db).compile();
+    const query = db
+        .selectFrom("users")
+        .selectAll("users")
+        .select((eb) => [withMissions, withTeams])
+        .compile();
 
     const userInfos = await db.executeQuery(query);
 
@@ -118,9 +128,8 @@ export async function getAllExpiredUsers(
     expirationDate: Date,
     db: Kysely<DB> = database
 ) {
-    const query = db
-        .selectFrom("users")
-        .select((eb) => [...MEMBER_PROTECTED_INFO, withMissions(eb)])
+    const query = protectedDataSelect(db)
+        .select((eb) => [withMissions(eb), withTeams(eb)])
         .where("primary_email", "is not", null)
         .where("primary_email_status", "in", [
             EmailStatusCode.EMAIL_DELETED,
@@ -182,6 +191,28 @@ function withMissions(eb: ExpressionBuilder<DB, "users">) {
     )
         .$notNull()
         .as("missions");
+}
+
+function withStartups(eb: ExpressionBuilder<DB, "users">) {
+    return jsonArrayFrom(
+        eb
+            .selectFrom(["startups"])
+            .leftJoin(
+                "missions_startups",
+                "missions_startups.startup_id",
+                "startups.uuid"
+            )
+            .leftJoin(
+                "missions",
+                "missions.uuid",
+                "missions_startups.mission_id"
+            )
+            .select(["startups.uuid", "startups.name"])
+            .whereRef("missions.user_id", "=", "users.uuid")
+            .groupBy(["startups.uuid"])
+    )
+        .$notNull()
+        .as("startups");
 }
 
 function withTeams(eb: ExpressionBuilder<DB, "users">) {
@@ -322,3 +353,47 @@ export const getLatests = (db: Kysely<DB> = database) => {
         .execute();
 };
 
+const protectedDataSelect = (db: Kysely<DB> = database) =>
+    db
+        .selectFrom("users")
+        .select([
+            "users.uuid",
+            "users.updated_at",
+            "users.username",
+            "users.fullname",
+            "users.role",
+            "users.domaine",
+            "users.bio",
+            "users.link",
+            "users.github",
+            "users.member_type",
+            "users.primary_email",
+            "users.secondary_email",
+            "users.primary_email_status",
+            "users.primary_email_status_updated_at",
+            "users.communication_email",
+            "users.email_is_redirection",
+            "users.workplace_insee_code",
+            "users.competences",
+        ]);
+export async function getUserStartupsActive(
+    uuid: string,
+    db: Kysely<DB> = database
+) {
+    const now = new Date();
+    return getUserStartups(uuid).then((startups) =>
+        startups.filter(
+            (startup) =>
+                isAfter(now, startup.start ?? 0) &&
+                isBefore(now, startup.end ?? Infinity)
+        )
+    );
+}
+
+export const getLatests = (db: Kysely<DB> = database) => {
+    return getAllUsersInfoQuery(db)
+        .select((eb) => [withStartups(eb)])
+        .orderBy("users.created_at", "desc")
+        .limit(10)
+        .execute();
+};

--- a/src/models/actionEvent/actionEvent.ts
+++ b/src/models/actionEvent/actionEvent.ts
@@ -367,7 +367,7 @@ export const EventMemberCreatedPayload = z.object({
         member: createMemberSchema._def.schema.shape.member,
         missions: createMemberSchema._def.schema.shape.missions,
         incubator_id:
-            createMemberSchema._def.schema.shape.incubator_id.nullable(),
+            createMemberSchema._def.schema.shape.incubator_id.optional(),
     }),
 });
 

--- a/src/server/infra/email/sendInBlue.ts
+++ b/src/server/infra/email/sendInBlue.ts
@@ -16,8 +16,8 @@ import {
     UpdateContactEmailProps,
     Contact,
     EmailVariants,
+    EMAIL_TYPES,
 } from "@modules/email";
-import React from "react";
 
 const TEMPLATE_ID_BY_TYPE: Record<EmailProps["type"], number> = {
     MARRAINAGE_NEWCOMER_EMAIL: 0,
@@ -48,6 +48,7 @@ const TEMPLATE_ID_BY_TYPE: Record<EmailProps["type"], number> = {
     EMAIL_PR_PENDING_TO_TEAM: 0,
     EMAIL_VERIFICATION_WAITING: 0,
     EMAIL_NEW_MEMBER_VALIDATION: 0,
+    [EMAIL_TYPES.EMAIL_TEAM_COMPOSITION]: 0,
 };
 
 type SendEmailFromSendinblueDeps = {

--- a/src/server/modules/email/email.ts
+++ b/src/server/modules/email/email.ts
@@ -6,6 +6,7 @@ import {
     memberBaseInfoSchemaType,
     memberPublicInfoSchemaType,
 } from "@/models/member";
+import { missionSchemaType } from "@/models/mission";
 import {
     StartupPhase,
     startupSchemaType,
@@ -42,6 +43,7 @@ export enum EMAIL_TYPES {
     EMAIL_TEST = "EMAIL_TEST",
     EMAIL_VERIFICATION_WAITING = "EMAIL_VERIFICATION_WAITING",
     EMAIL_NEW_MEMBER_VALIDATION = "EMAIL_NEW_MEMBER_VALIDATION",
+    EMAIL_TEAM_COMPOSITION = "EMAIL_TEAM_COMPOSITION",
 }
 
 export type SubjectFunction = {
@@ -288,6 +290,18 @@ export type EmailNewMemberValidation = {
     };
 };
 
+export type EmailTeamComposition = {
+    type: EMAIL_TYPES.EMAIL_TEAM_COMPOSITION;
+    variables: {
+        activeMembers: {
+            member: memberPublicInfoSchemaType;
+            activeMission: missionSchemaType;
+        }[];
+        startup: startupSchemaType;
+        memberAccountLink: string;
+    };
+};
+
 export type EmailVariants =
     | EmailMarrainageNewcomer
     | EmailMarrainageOnboarder
@@ -313,7 +327,8 @@ export type EmailVariants =
     | EmailTest
     | EmailPRPendingToTeam
     | EmailVerificationWaiting
-    | EmailNewMemberValidation;
+    | EmailNewMemberValidation
+    | EmailTeamComposition;
 
 export type EmailProps = BaseEmail & EmailVariants;
 

--- a/src/server/modules/htmlbuilder/htmlbuilder.ts
+++ b/src/server/modules/htmlbuilder/htmlbuilder.ts
@@ -7,10 +7,16 @@ import {
     MemberValidationEmail,
     MemberValidationEmailTitle,
 } from "@/server/views/templates/emails/memberValidationEmail/memberValidationEmail";
+import {
+    TeamCompositionEmail,
+    TeamCompositionEmailTitle,
+} from "@/server/views/templates/emails/teamCompositionEmail/teamCompositionEmail";
 import { BusinessError } from "@/utils/error";
 import {
+    EMAIL_TYPES,
     EmailNewMemberValidation,
     EmailProps,
+    EmailTeamComposition,
     HtmlBuilderType,
     SubjectFunction,
 } from "@modules/email";
@@ -63,6 +69,9 @@ const TEMPLATES_BY_TYPE: Record<EmailProps["type"], string | null | any> = {
     EMAIL_NEW_MEMBER_VALIDATION: (
         params: EmailNewMemberValidation["variables"]
     ) => MemberValidationEmail(params),
+    [EMAIL_TYPES.EMAIL_TEAM_COMPOSITION]: (
+        params: EmailTeamComposition["variables"]
+    ) => TeamCompositionEmail(params),
 };
 
 const SUBJECTS_BY_TYPE: Record<EmailProps["type"], string | SubjectFunction> = {
@@ -110,6 +119,7 @@ const SUBJECTS_BY_TYPE: Record<EmailProps["type"], string | SubjectFunction> = {
     EMAIL_TEST: "",
     EMAIL_VERIFICATION_WAITING: "Bienvenue chez BetaGouv 🙂",
     EMAIL_NEW_MEMBER_VALIDATION: MemberValidationEmailTitle(),
+    [EMAIL_TYPES.EMAIL_TEAM_COMPOSITION]: TeamCompositionEmailTitle(),
 };
 
 const MARKDOWN_BY_TYPE: Record<EmailProps["type"], boolean> = {
@@ -141,6 +151,7 @@ const MARKDOWN_BY_TYPE: Record<EmailProps["type"], boolean> = {
     EMAIL_TEST: false,
     EMAIL_VERIFICATION_WAITING: false,
     EMAIL_NEW_MEMBER_VALIDATION: false,
+    [EMAIL_TYPES.EMAIL_TEAM_COMPOSITION]: false,
 };
 
 const htmlBuilder: HtmlBuilderType = {

--- a/src/server/queueing/client.ts
+++ b/src/server/queueing/client.ts
@@ -14,6 +14,10 @@ import {
     createOrUpdateMatomoServiceAccountTopic,
 } from "./workers/create-update-matomo-account";
 import {
+    sendEmailToTeamsToCheckOnTeamComposition,
+    sendEmailToTeamsToCheckOnTeamCompositionTopic,
+} from "./workers/send-email-to-teams-to-check-on-team-composition";
+import {
     sendNewMemberValidationEmail,
     sendNewMemberValidationEmailTopic,
 } from "./workers/send-validation-email";
@@ -87,6 +91,10 @@ export async function startBossClientInstance(): Promise<PgBoss> {
         await bossClient.work(
             sendNewMemberValidationEmailTopic,
             handlerWrapper(sendNewMemberValidationEmail)
+        );
+        await bossClient.work(
+            sendEmailToTeamsToCheckOnTeamCompositionTopic,
+            handlerWrapper(sendEmailToTeamsToCheckOnTeamComposition)
         );
     });
 }

--- a/src/server/queueing/schedule.ts
+++ b/src/server/queueing/schedule.ts
@@ -1,0 +1,14 @@
+import { startBossClientInstance } from "./client";
+import { sendEmailToTeamsToCheckOnTeamCompositionTopic } from "./workers/send-email-to-teams-to-check-on-team-composition";
+
+export async function scheduleCronTasks() {
+    const bossClient = await startBossClientInstance();
+
+    // cron tasks
+    await bossClient.schedule(
+        sendEmailToTeamsToCheckOnTeamCompositionTopic,
+        `0 8 1,2,3,4,5,6,7 */3 1`, // Runs at 08:00 AM on monday every 3rd month
+        undefined,
+        { tz: "Europe/Paris" }
+    );
+}

--- a/src/server/queueing/workers/send-email-to-teams-to-check-on-team-composition.spec.ts
+++ b/src/server/queueing/workers/send-email-to-teams-to-check-on-team-composition.spec.ts
@@ -1,0 +1,64 @@
+import { Selectable } from "kysely";
+import PgBoss from "pg-boss";
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+
+import { Users } from "@/@types/db";
+import { db } from "@/lib/kysely";
+import { getUserByStartup } from "@/lib/kysely/queries/users";
+import {
+    memberBaseInfoToModel,
+    memberPublicInfoToModel,
+    startupToModel,
+} from "@/models/mapper";
+import config from "@/server/config";
+import { EMAIL_TYPES } from "@/server/modules/email";
+import testUsers from "__tests__/users.json";
+import utils from "__tests__/utils";
+
+describe("sendEmailToTeamsToCheckOnTeamComposition()", () => {
+    let sendEmailStub,
+        getServerSessionStub,
+        sendEmailToTeamsToCheckOnTeamComposition;
+    let userA: Selectable<Users>, userB: Selectable<Users>;
+    beforeEach(async () => {
+        getServerSessionStub = sinon.stub();
+        await utils.createUsers(testUsers);
+        sendEmailStub = sinon.stub().resolves(); // Resolves like a real async function
+        // Use proxyquire to replace bossClient module
+        sendEmailToTeamsToCheckOnTeamComposition = proxyquire(
+            "@/server/queueing/workers/send-email-to-teams-to-check-on-team-composition",
+            {
+                "@/server/config/email.config": { sendEmail: sendEmailStub },
+            }
+        ).sendEmailToTeamsToCheckOnTeamComposition;
+    });
+
+    afterEach(async () => {
+        await utils.deleteUsers(testUsers);
+    });
+
+    it("should send email listing teams member", async () => {
+        await sendEmailToTeamsToCheckOnTeamComposition({
+            data: {},
+        } as unknown as PgBoss.Job<void>);
+        const startup = await db
+            .selectFrom("startups")
+            .selectAll()
+            .where("name", "=", "test-startup")
+            .executeTakeFirstOrThrow();
+        const usersByStartup = await getUserByStartup(startup.uuid);
+        sendEmailStub.firstCall.args[0].should.deep.equal({
+            toEmail: [`${startup.mailing_list}@${config.domain}`],
+            type: EMAIL_TYPES.EMAIL_TEAM_COMPOSITION,
+            variables: {
+                activeMembers: usersByStartup.map((u) => ({
+                    member: memberBaseInfoToModel(u),
+                    activeMission: memberBaseInfoToModel(u).missions[0],
+                })),
+                memberAccountLink: `${config.protocol}://${config.host}/account/base-info`,
+                startup: startupToModel(startup),
+            },
+        });
+    });
+});

--- a/src/server/queueing/workers/send-email-to-teams-to-check-on-team-composition.ts
+++ b/src/server/queueing/workers/send-email-to-teams-to-check-on-team-composition.ts
@@ -1,0 +1,88 @@
+import PgBoss from "pg-boss";
+
+import { db } from "@/lib/kysely";
+import { getUsersByStartupIds } from "@/lib/kysely/queries/users";
+import { memberBaseInfoToModel } from "@/models/mapper";
+import { startupToModel } from "@/models/mapper";
+import { memberBaseInfoSchemaType } from "@/models/member";
+import config from "@/server/config";
+import { sendEmail } from "@/server/config/email.config";
+import { BusinessError } from "@/utils/error";
+import { EMAIL_TYPES } from "@modules/email";
+
+export const sendEmailToTeamsToCheckOnTeamCompositionTopic =
+    "send-email-to-teams-to-check-on-team-composition";
+
+export async function sendEmailToTeamsToCheckOnTeamComposition(
+    job: PgBoss.Job<void>
+) {
+    const startups = (
+        await db
+            .selectFrom("startups")
+            .selectAll(["startups"])
+            .leftJoin("phases", (join) =>
+                join
+                    .onRef("phases.startup_id", "=", "startups.uuid")
+                    .on("phases.name", "in", ["success", "transfer", "alumni"])
+            )
+            .where("mailing_list", "is not", null)
+            .where("phases.name", "is", null)
+            .execute()
+    ).map((startup) => startupToModel(startup));
+
+    if (!startups.length) {
+        console.log(
+            `There is no startups in active startups with mailing list`
+        );
+        return;
+    }
+    console.log(`Will send email to ${startups.length} mailing lists`);
+    const now = new Date();
+    const usersByStartup = await getUsersByStartupIds(
+        startups.map((startup) => startup.uuid)
+    );
+    for (const startup_id in usersByStartup) {
+        const startup = startups.find((startup) => startup.uuid === startup_id);
+        if (!startup) {
+            throw new BusinessError(
+                "startupShouldExists",
+                "Startup should exists"
+            );
+        }
+        const users = usersByStartup[startup_id];
+        const activeStartupMembers = users
+            .map((user) => {
+                const member = memberBaseInfoToModel(user);
+                const activeMission = member.missions.find((mission) => {
+                    return (
+                        now >= mission.start &&
+                        (!mission.end || now <= mission.end) &&
+                        mission.startups?.includes(startup_id)
+                    );
+                });
+                if (!activeMission) return null; // Explicitly return null if no mission
+
+                return {
+                    member,
+                    activeMission,
+                };
+            })
+            .filter(
+                (
+                    member
+                ): member is {
+                    member: memberBaseInfoSchemaType;
+                    activeMission: memberBaseInfoSchemaType["missions"][0];
+                } => member !== null
+            );
+        await sendEmail({
+            type: EMAIL_TYPES.EMAIL_TEAM_COMPOSITION,
+            variables: {
+                activeMembers: activeStartupMembers,
+                startup: startup,
+                memberAccountLink: `${config.protocol}://${config.host}/account/base-info`,
+            },
+            toEmail: [`${startup.mailing_list}@${config.domain}`],
+        });
+    }
+}

--- a/src/server/schedulers/startups/sendEmailToStartupToUpdatePhase.ts
+++ b/src/server/schedulers/startups/sendEmailToStartupToUpdatePhase.ts
@@ -19,7 +19,7 @@ export const sendEmailToStartupToUpdatePhase = async (
             await db
                 .selectFrom("startups")
                 .selectAll()
-                .where("mailing_list", "is not", "null")
+                .where("mailing_list", "is not", null)
                 .execute()
         ).map((startup) => startupToModel(startup));
     // .whereIn("current_phase", ACTIVE_PHASES)

--- a/src/server/scripts/runSendEmail.ts
+++ b/src/server/scripts/runSendEmail.ts
@@ -1,0 +1,6 @@
+import { sendEmailToTeamsToCheckOnTeamComposition } from "@/server/queueing/workers/send-email-to-teams-to-check-on-team-composition";
+sendEmailToTeamsToCheckOnTeamComposition({
+    id: "",
+    name: "",
+    data: undefined,
+});

--- a/src/server/views/templates/emails/teamCompositionEmail/teamCompositionEmail.tsx
+++ b/src/server/views/templates/emails/teamCompositionEmail/teamCompositionEmail.tsx
@@ -1,0 +1,93 @@
+import {
+    MjmlButton,
+    MjmlText,
+    Mjml,
+    MjmlHead,
+    MjmlPreview,
+    MjmlTitle,
+    MjmlBody,
+    MjmlSection,
+    MjmlColumn,
+} from "@luma-team/mjml-react";
+import { format } from "date-fns";
+import { fr } from "date-fns/locale";
+
+import { StandardLayout } from "@/components/emails/layouts/StandardEmail";
+import { EmailTeamComposition } from "@/server/modules/email";
+export function TeamCompositionEmailTitle() {
+    return `Vérifie les membres de ton équipe.`;
+}
+
+export function TeamCompositionEmail(props: EmailTeamComposition["variables"]) {
+    const title = TeamCompositionEmailTitle();
+
+    return (
+        <StandardLayout title={title}>
+            <MjmlText>
+                <h1>{title}</h1>
+                <p>Bonjour,</p>
+                <p>
+                    Tu reçois cet email car tu fais partie de l'équipe :{" "}
+                    {props.startup.name}.
+                </p>
+                <p>Voici les membres actuellement dans ton équipe : </p>
+                <table className="member-info" style={{ width: "100%" }}>
+                    <thead>
+                        <tr>
+                            <th>Nom</th>
+                            <th>Rôle</th>
+                            <th>Mission</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {props.activeMembers.map((activeMember, index) => (
+                            <tr key={index}>
+                                <td style={{ width: "25%" }}>
+                                    {activeMember.member.fullname}
+                                </td>
+                                <td style={{ width: "40%" }}>
+                                    {activeMember.member.role}
+                                </td>
+                                <td style={{ width: "35%" }}>
+                                    Début :{" "}
+                                    {format(
+                                        activeMember.activeMission.start,
+                                        "dd/MM/yyyy",
+                                        { locale: fr }
+                                    )}{" "}
+                                    <br />
+                                    Fin:{" "}
+                                    {!!activeMember.activeMission.end
+                                        ? format(
+                                              activeMember.activeMission.end,
+                                              "dd/MM/yyyy",
+                                              { locale: fr }
+                                          )
+                                        : "Pas de date de fin"}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </MjmlText>
+            <MjmlText>
+                <p>
+                    Si tes informations ne sont pas à jour, tu peux les modifier en cliquant sur le bouton ci-dessous.
+                </p>
+            </MjmlText>
+            <MjmlButton href={props.memberAccountLink}>
+                Changer mes informations
+            </MjmlButton>
+            <MjmlText>
+                <p className="fr-hr-or">ou</p>
+            </MjmlText>
+            <MjmlText>
+                <p>
+                    Si un des autres membres n'est plus dans l'équipe tu peux le
+                    signaler aux responsables de ton incubateur.
+                </p>
+            </MjmlText>
+            <MjmlText></MjmlText>
+        </StandardLayout>
+    );
+}

--- a/src/server/views/utils/email.ts
+++ b/src/server/views/utils/email.ts
@@ -1,0 +1,28 @@
+import { compile } from "html-to-text";
+import { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+export const convertHtmlEmailToText = compile({
+    wordwrap: 130,
+    selectors: [
+        { selector: "head", format: "skip" },
+        // TODO: find a way to detect data tables and add to them a specific class to be selected here
+        // { selector: 'table', format: 'dataTable' },
+        { selector: ".logo-section", format: "skip" },
+        { selector: ".social-network-section", format: "skip" },
+    ],
+});
+
+export function convertComponentEmailToText(component: ReactElement) {
+    const html = renderToStaticMarkup(component);
+
+    return convertHtmlEmailToText(html);
+}
+
+export const commonEmailsParameters = {
+    layout: "fullscreen",
+    // TODO: for now we have a race condition on rendering it the first time so it breaks tests into Chromatic,
+    // we disable the snapshots for now until we find a solution. Same for local test runners.
+    chromatic: { disableSnapshot: true },
+    testRunner: { disable: true },
+};

--- a/src/utils/gracefulExist.ts
+++ b/src/utils/gracefulExist.ts
@@ -1,0 +1,20 @@
+import * as Sentry from "@sentry/nextjs";
+
+import { stopBossClientInstance } from "@/server/queueing/client";
+
+export async function gracefulExit(error?: Error) {
+    if (error) {
+        console.error(error);
+
+        Sentry.captureException(error);
+    }
+
+    console.log("Exiting the application gracefully...");
+
+    // Perform any necessary cleanup or finalization tasks here
+    try {
+        await Promise.all([stopBossClientInstance(), Sentry.close(2000)]);
+    } finally {
+        process.exit(error ? 1 : 0);
+    }
+}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -56,6 +56,7 @@
         "models",
         "src/lib",
         "knexfile.js",
+        "**/**.spec.ts",
         "dist"
     ]
 }


### PR DESCRIPTION
- ajoute le script d'envoie d'email tous les 3 mois aux membre des startups
- ~~utilisation de pgboss depuis le bundle next pour gérer ce cron : l'email, les dépendences scss sont géré côté next car le build ttsc ne buildait pas l'utilisation du scss dans l'email.~~
- ~~les taches pgboss sont donc maintenant lancés depuis next (au lieu de cron.ts) grace au run du script start-and-wait-to-init~~
- ~~ajout de storybook : permet la visualisation des emails, et à terme de nos différents composant ui qui commence à être nombreux
(je n'ai pas encore intégré le push sur chromatic à la ci, mais j'ai pour l'instant fait un push manuel)~~
https://67bdd3c4900b1b3e4fce6589-liglwewenr.chromatic.com/?path=/story/emails-templates-teamcompositionemail--complete
- ~~remplacement de ttsc par un build avec esbuild : j'ai finalemement réussi a builder les fichiers scss avec esbuild, ce qui permet de dry-run les scripts qui envoie des emails en prenant en compte le scss.~~