### PR TITLE
ui: wrap memberValidationEmail with standartEmail

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,9 +1,8 @@
 fileignoreconfig:
-- filename: package-lock.json
-  checksum: e8ab779fc8fdbf1f46a33306b37387ce252f735b07469f0dbcd75a316a8f9599
+- filename: src/server/views/templates/emails/memberValidationEmail/memberValidationEmail.tsx
+  checksum: ac00a05d789b605843b01a7bfa8ab34a99179f3e84c5fbcf457dde6620857f2f
 version: ""
-ock.json
-  checksum: 9c740513497d70e871e4abcad3a9e509ef5b1a0da9db2d0d2d336c19854303b4
+b2d0d2d336c19854303b4
 - filename: src/app/(private)/(dashboard)/community/communes.json
   checksum: f69dbcbfe5e1e7c1bd9340c7bb3d9de9cbc9d4080363e80d8b4da190fb6ae045
 - filename: src/app/(private)/(dashboard)/incubators/[id]/info-form/page.tsx

--- a/src/server/views/templates/emails/memberValidationEmail/memberValidationEmail.tsx
+++ b/src/server/views/templates/emails/memberValidationEmail/memberValidationEmail.tsx
@@ -10,6 +10,7 @@ import {
     MjmlColumn,
 } from "@luma-team/mjml-react";
 
+import { StandardLayout } from "@/components/emails/layouts/StandardEmail";
 import { EmailNewMemberValidation } from "@/server/modules/email";
 
 export function MemberValidationEmailTitle() {
@@ -22,57 +23,42 @@ export function MemberValidationEmail(
     const title = MemberValidationEmailTitle();
 
     return (
-        <Mjml>
-            <MjmlHead>
-                <MjmlTitle>Nouveau membre à valider</MjmlTitle>
-                <MjmlPreview>Une nouvelle fiche membre a été créée avec une mission qui concerne ton incubateur</MjmlPreview>
-            </MjmlHead>
-            <MjmlBody width={500}>
-                <MjmlSection>
-                    <MjmlColumn>
-                        <MjmlText>
-                            <h1>{title}</h1>
-                            <p>Bonjour,</p>
-                            <p>
-                                Tu reçois cet email car tu fais partie d'une
-                                équipe transverse de l'incubateur :{" "}
-                                {props.incubator.title}
-                            </p>
-                            <p>
-                                Une nouvelle fiche membre a été créée avec une
-                                mission qui concerne ton incubateur. Merci de
-                                valider cette fiche si tu es au courant de
-                                l'arrivée de cette personne.
-                            </p>
-                            <p>
-                                <ul>
-                                    <li key={"fullname"}>
-                                        Prénom Nom : {props.userInfos.fullname}
-                                    </li>
-                                    <li>Domaine : {props.userInfos.domaine}</li>
-                                    <li>
-                                        Produits :{" "}
-                                        {props.startups
-                                            .map((s) => s.name)
-                                            .join(", ")}
-                                    </li>
-                                </ul>
-                            </p>
-                        </MjmlText>
-                        <MjmlText>
-                            <p>
-                                Cette personne est-elle bien un membre de ton
-                                incubateur ? Si oui, clique sur le bouton
-                                ci-dessous.
-                            </p>
-                        </MjmlText>
-                        <MjmlButton href={props.validationLink}>
-                            Valider le membre
-                        </MjmlButton>
-                        <MjmlText></MjmlText>
-                    </MjmlColumn>
-                </MjmlSection>
-            </MjmlBody>
-        </Mjml>
+        <StandardLayout title={title}>
+            <MjmlText>
+                <h1>{title}</h1>
+                <p>Bonjour,</p>
+                <p>
+                    Tu reçois cet email car tu fais partie d'une équipe
+                    transverse de l'incubateur : {props.incubator.title}
+                </p>
+                <p>
+                    Une nouvelle fiche membre a été créée avec une mission qui
+                    concerne ton incubateur. Merci de valider cette fiche si tu
+                    es au courant de l'arrivée de cette personne.
+                </p>
+                <p>
+                    <ul>
+                        <li key={"fullname"}>
+                            Prénom Nom : {props.userInfos.fullname}
+                        </li>
+                        <li>Domaine : {props.userInfos.domaine}</li>
+                        <li>
+                            Produits :{" "}
+                            {props.startups.map((s) => s.name).join(", ")}
+                        </li>
+                    </ul>
+                </p>
+            </MjmlText>
+            <MjmlText>
+                <p>
+                    Cette personne est-elle bien un membre de ton incubateur ?
+                    Si oui, clique sur le bouton ci-dessous.
+                </p>
+            </MjmlText>
+            <MjmlButton href={props.validationLink}>
+                Valider le membre
+            </MjmlButton>
+            <MjmlText></MjmlText>
+        </StandardLayout>
     );
 }


### PR DESCRIPTION
Pour avoir la même design que sur les autres emails : 
https://67bdd3c4900b1b3e4fce6589-ossjmiwkla.chromatic.com/?path=/story/emails-templates-membervalidationemail--normal

<img width="506" alt="Screenshot 2025-03-05 at 23 34 47" src="https://github.com/user-attachments/assets/95df5ba7-a348-4ede-9f8f-f466797d4f42" />
