### PR TITLE
fix(community): better active filter

### DIFF
--- a/src/components/CommunityPage/Community.tsx
+++ b/src/components/CommunityPage/Community.tsx
@@ -210,13 +210,20 @@ export const Community = (props: CommunityProps) => {
                         );
                     } else if (filter.type === "startup" && filter.value) {
                         // test if user had a mission in given startup
-                        // todo: when active_only, only show startup active members
                         const user = props.users.find(
                             (u) => u.uuid === result.uuid
+                        );
+                        const activeOnly = filters.find(
+                            (f) => f.type == "active_only" && !!f.value
                         );
                         return (
                             user &&
                             user.missions
+                                .filter((m) =>
+                                    activeOnly
+                                        ? !m.end || m.end > new Date()
+                                        : true
+                                )
                                 .flatMap((m) => m.startups)
                                 .includes(filter.value.toString())
                         );

--- a/src/lib/kysely/queries/incubators.ts
+++ b/src/lib/kysely/queries/incubators.ts
@@ -93,6 +93,13 @@ export async function getAllIncubatorsMembers() {
                         "startups.uuid",
                         "missions_startups.startup_id"
                     )
+                    // only include active users
+                    .where((eb) =>
+                        eb.or([
+                            eb("missions.end", "is", null),
+                            eb("missions.end", ">=", new Date()),
+                        ])
+                    )
                     .whereRef("startups.incubator_id", "=", "incubators.uuid")
                     .union(() =>
                         // team members affiliated to incubator


### PR DESCRIPTION
 - quand on cherche une SE + filtre actif, n'affiche que les membres actifs de la SE
 - `getAllIncubatorsMembers`: ne renvoie que les membres actifs des SEs

Impact sur la route `api/protected/incubator/route.ts` : les membres qui ne sont plus actifs dans les SEs ne seront plus retournés