### PR TITLE
chore: changed label for highlighted_startups

### DIFF
--- a/src/components/IncubatorForm/IncubatorForm.tsx
+++ b/src/components/IncubatorForm/IncubatorForm.tsx
@@ -386,7 +386,7 @@ export function IncubatorForm(props: IncubatorFormProps) {
                         isMulti={true}
                         placeholder={`Sélectionne un ou plusieurs produits`}
                         startups={props.startupOptions}
-                        label="Produits portés par l'incubateur :"
+                        label="Produits phares de l'incubateur :"
                     />
                     <hr />
                     <UploadForm


### PR DESCRIPTION
Le label actuel prête à confusion, on a l'impression qu'il faut mettre tous les produits de l'incubateur. Il s'agit en fait uniquement des produits à mettre en avant sur le site beta. 
