### PR TITLE
chore: incubator logo should be rectangle

### DIFF
--- a/src/components/IncubatorForm/IncubatorForm.tsx
+++ b/src/components/IncubatorForm/IncubatorForm.tsx
@@ -403,6 +403,7 @@ export function IncubatorForm(props: IncubatorFormProps) {
                                 setValue("shouldDeleteLogo", false);
                             }
                         }}
+                        shape={"rectangle"}
                         url={props.logoURL}
                         onDelete={() => {
                             setValue("logo", null, {


### PR DESCRIPTION
~~ça semble fixé le problème, mais pourtant le default de shape devait devait déjà être "rectangular"~~ Le default de shape dans fichePicture était round, donc c'était bien cassé. La preview de l'image reste cependant différente de comment elle apparaitra sur le site, on peut sans doute travailler la-dessus dans un autre PR => j'ouvre une issue