### PR TITLE
feat: upload all source maps and ignore minified errors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -90,6 +90,8 @@ const sentryWebpackPluginOptions = {
     release: process.env.SOURCE_VERSION, // https://doc.scalingo.com/platform/app/environment#build-environment-variables
     org: "betagouv",
     project: "espace-membre",
+    widenClientFileUpload: true, // https://sentry.zendesk.com/hc/en-us/articles/28813179249691-Frames-from-static-chunks-folder-are-not-source-mapped
+    // cause static/chunks/ to be uploaded
     // An auth token is required for uploading source maps.
     authToken: process.env.SENTRY_AUTH_TOKEN,
     url: "https://sentry.incubateur.net",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -13,4 +13,8 @@ Sentry.init({
     // plus for 100% of sessions with an error
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1,
+    ignoreErrors: [
+        "https://reactjs.org/docs/error-decoder.html?invariant=418", // ignore minified react error
+        "https://reactjs.org/docs/error-decoder.html?invariant=423", // ignore minified react error
+    ],
 });


### PR DESCRIPTION
Les changements minimum pour améliorer les choses après avoir tester plein de config.
Les release sont bien envoyé et les source maps uploadés. 
Il y a des mismatchs de source map quand l'erreur vient des chunks next, l'ajout de widenClientFileUpload permet de les avoirs dans les sourcemaps. Ce sont des fichiers minifiés donc c'est pas extrémement lisible. 
A voir si ça nous sert, j'ai pas l'impression que le build soit beaucoup plus long.
J'ai mis les erreurs de minifications/hydration à ignorer. Normalement la config côté sentry.incubateur.net est sensé le faire mais ça ne semble pas s'appliquer.
Ces erreurs floodent trop les alertes à mon avis.