### PR TITLE
fix(validation): allow null incubator

### DIFF
--- a/__tests__/test-create-member-validation.ts
+++ b/__tests__/test-create-member-validation.ts
@@ -247,7 +247,7 @@ describe(`Test creating new user flow : A new member cannot be validated by some
         } catch (error) {
             error.should.be.instanceof(BusinessError);
             (error as BusinessError).code.should.be.equals(
-                "userIsNotWaitingValidation"
+                "userAlreadyValided"
             );
         }
     });

--- a/src/app/api/member/actions/validateNewMember.ts
+++ b/src/app/api/member/actions/validateNewMember.ts
@@ -76,7 +76,7 @@ export async function validateNewMember({
     ) {
         throw new BusinessError(
             "userAlreadyValided",
-            `Le nouveau membre a déjà été validé`
+            `Ce membre a déjà été validé`
         );
     }
     const newMember = memberBaseInfoToModel(rawData);

--- a/src/app/api/member/actions/validateNewMember.ts
+++ b/src/app/api/member/actions/validateNewMember.ts
@@ -31,7 +31,7 @@ export async function validateNewMember({
     if (!rawData) {
         throw new BusinessError(
             "userNotFound",
-            `Aucun utilisateur trouver pour l'identifiant : ${memberUuid}`
+            `Aucun utilisateur trouvé pour l'identifiant : ${memberUuid}`
         );
     }
 
@@ -75,8 +75,8 @@ export async function validateNewMember({
         EmailStatusCode.MEMBER_VALIDATION_WAITING
     ) {
         throw new BusinessError(
-            "userIsNotWaitingValidation",
-            `${rawData.fullname} (identifiant:${memberUuid}) n'est pas en attente de validation`
+            "userAlreadyValided",
+            `Le nouveau membre a déjà été validé`
         );
     }
     const newMember = memberBaseInfoToModel(rawData);

--- a/src/models/actionEvent/actionEvent.ts
+++ b/src/models/actionEvent/actionEvent.ts
@@ -366,8 +366,9 @@ export const EventMemberCreatedPayload = z.object({
     action_metadata: z.object({
         member: createMemberSchema._def.schema.shape.member,
         missions: createMemberSchema._def.schema.shape.missions,
-        incubator_id:
-            createMemberSchema._def.schema.shape.incubator_id.optional(),
+        incubator_id: createMemberSchema._def.schema.shape.incubator_id
+            .optional()
+            .nullable(),
     }),
 });
 


### PR DESCRIPTION
This prevent an exception when the original event metadata has no incubator set.