### PR TITLE
fix(startup-page): pass se.uuid instead of ghid

### DIFF
--- a/src/app/(private)/(dashboard)/startups/[id]/page.tsx
+++ b/src/app/(private)/(dashboard)/startups/[id]/page.tsx
@@ -88,13 +88,13 @@ export default async function Page({ params }: Props) {
     const sentryTeams = (
         await db
             .selectFrom("sentry_teams")
-            .where("startup_id", "=", params.id)
+            .where("startup_id", "=", dbSe.uuid)
             .selectAll()
             .execute()
     ).map(sentryTeamToModel);
     const matomoSites = await db
         .selectFrom("matomo_sites")
-        .where("startup_id", "=", params.id)
+        .where("startup_id", "=", dbSe.uuid)
         .selectAll()
         .execute();
     const startup = startupToModel(dbSe);


### PR DESCRIPTION
L'accès à la page startup via le github id : `startups/zero-logement-vacant` est cassé. 
On utilise le params.id pour récupérer les comptes matomo et sentry lié au produit, mais params.id est le ghid et non le uuid de la startup : invalid input syntax for type uuid: "zero-logement-vacant"
