### PR TITLE
chore: allow opi user to changed primary email

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,8 +1,4 @@
 fileignoreconfig:
-- filename: src/components/MemberPage/Email/EmailContainer.tsx
-  checksum: 0cc4c19cc140c7643a9598a76c3c96dcf5023642eb61a1890147e3f4fe28972b
-version: ""
-me: src/app/api/member/[username]/route.ts
   checksum: a5371c646bc9955b72b6cdb5ee3aef340004a092d9e70bbbe4b308c940880370
 - filename: src/app/api/member/actions/createRedirectionForUser.ts
   checksum: 12c54f94e0d66d8e3d51b9e9dd7032a1757c50fc85733b29befe9c0162fe3251

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,7 +1,8 @@
 fileignoreconfig:
-- filename: src/app/(private)/(dashboard)/formations/[id]/page.tsx
-  checksum: f48fbb61095d33e5fc2d9135b3dd811fa8018cdbf0b1fdcaf8b78fda8e5a0d24
-- filename: src/app/api/member/[username]/route.ts
+- filename: src/components/MemberPage/Email/EmailContainer.tsx
+  checksum: 0cc4c19cc140c7643a9598a76c3c96dcf5023642eb61a1890147e3f4fe28972b
+version: ""
+me: src/app/api/member/[username]/route.ts
   checksum: a5371c646bc9955b72b6cdb5ee3aef340004a092d9e70bbbe4b308c940880370
 - filename: src/app/api/member/actions/createRedirectionForUser.ts
   checksum: 12c54f94e0d66d8e3d51b9e9dd7032a1757c50fc85733b29befe9c0162fe3251

--- a/src/components/MemberPage/Email/EmailContainer.tsx
+++ b/src/components/MemberPage/Email/EmailContainer.tsx
@@ -357,31 +357,33 @@ export default function EmailContainer({
                     <BlocConfigurerCommunicationEmail userInfos={userInfos} />
                 </>
             )}
-            {!emailIsBeingCreated && isCurrentUser && !isMailOPI && (
+            {!emailIsBeingCreated && isCurrentUser && (
                 <div className={fr.cx("fr-accordions-group")}>
-                    {match(userInfos.primary_email_status)
-                        .with(
-                            EmailStatusCode.EMAIL_CREATION_WAITING,
-                            EmailStatusCode.EMAIL_CREATION_PENDING,
-                            () => null
-                        )
-                        .otherwise(
-                            () =>
-                                canCreateEmail && (
-                                    <BlocCreateEmail
-                                        hasPublicServiceEmail={
-                                            hasPublicServiceEmail
-                                        }
-                                        userInfos={userInfos}
-                                    />
-                                )
-                        )}
+                    {!isMailOPI &&
+                        match(userInfos.primary_email_status)
+                            .with(
+                                EmailStatusCode.EMAIL_CREATION_WAITING,
+                                EmailStatusCode.EMAIL_CREATION_PENDING,
+                                () => null
+                            )
+                            .otherwise(
+                                () =>
+                                    canCreateEmail && (
+                                        <BlocCreateEmail
+                                            hasPublicServiceEmail={
+                                                hasPublicServiceEmail
+                                            }
+                                            userInfos={userInfos}
+                                        />
+                                    )
+                            )}
 
-                    {!!emailInfos && (
+                    {!!emailInfos && !isMailOPI && (
                         <BlocEmailConfiguration emailInfos={emailInfos} />
                     )}
 
-                    {emailInfos &&
+                    {!isMailOPI &&
+                        emailInfos &&
                         emailInfos.emailPlan ===
                             EMAIL_PLAN_TYPE.EMAIL_PLAN_BASIC && (
                             <>
@@ -399,11 +401,13 @@ export default function EmailContainer({
                             </>
                         )}
 
-                    <BlocChangerMotDePasse
-                        canChangePassword={canChangePassword}
-                        status={userInfos.primary_email_status}
-                        userInfos={userInfos}
-                    />
+                    {!isMailOPI && (
+                        <BlocChangerMotDePasse
+                            canChangePassword={canChangePassword}
+                            status={userInfos.primary_email_status}
+                            userInfos={userInfos}
+                        />
+                    )}
 
                     <BlocConfigurerEmailPrincipal
                         canChangeEmails={canChangeEmails}


### PR DESCRIPTION
Les utilisateurs avec email OPI devrait quand même voir : changement email principal, changement email secondaire, changement communitcation email.