### PR TITLE
chore(email): quote within quote break infomaniak reading css style

### DIFF
--- a/src/components/emails/layouts/StandardEmail.tsx
+++ b/src/components/emails/layouts/StandardEmail.tsx
@@ -57,13 +57,10 @@ export function StandardLayout(props: PropsWithChildren<StandardLayoutProps>) {
                         lineHeight="24px"
                         padding="8px 16px"
                     ></MjmlButton>
-                    {/* <MjmlAll fontFamily="&quot;Marianne&quot;, arial, sans-serif"></MjmlAll> */}
+                    <MjmlAll fontFamily="arial, sans-serif"></MjmlAll>
                 </MjmlAttributes>
                 <MjmlStyle>
                     {`
-                        * {
-                            font-family: 'Marianne', arial, sans-serif;
-                        }
                         hr {
                         color: #000000; // Otherwise it's grey
                         }

--- a/src/components/emails/layouts/StandardEmail.tsx
+++ b/src/components/emails/layouts/StandardEmail.tsx
@@ -41,7 +41,7 @@ export function StandardLayout(props: PropsWithChildren<StandardLayoutProps>) {
                         border-width="1px"
                         border-color="#000000"
                     ></MjmlDivider>
-                    <MjmlAll fontFamily='"Marianne", arial, sans-serif'></MjmlAll>
+                    <MjmlAll fontFamily="&quot;Marianne&quot;, arial, sans-serif"></MjmlAll>
                     <MjmlText
                         cssClass="light-text"
                         color="#3a3a3a"

--- a/src/components/emails/layouts/StandardEmail.tsx
+++ b/src/components/emails/layouts/StandardEmail.tsx
@@ -41,7 +41,6 @@ export function StandardLayout(props: PropsWithChildren<StandardLayoutProps>) {
                         border-width="1px"
                         border-color="#000000"
                     ></MjmlDivider>
-                    <MjmlAll fontFamily="&quot;Marianne&quot;, arial, sans-serif"></MjmlAll>
                     <MjmlText
                         cssClass="light-text"
                         color="#3a3a3a"
@@ -58,9 +57,14 @@ export function StandardLayout(props: PropsWithChildren<StandardLayoutProps>) {
                         lineHeight="24px"
                         padding="8px 16px"
                     ></MjmlButton>
+                    {/* <MjmlAll fontFamily="&quot;Marianne&quot;, arial, sans-serif"></MjmlAll> */}
                 </MjmlAttributes>
                 <MjmlStyle>
-                    {`hr {
+                    {`
+                        * {
+                            font-family: 'Marianne', arial, sans-serif;
+                        }
+                        hr {
                         color: #000000; // Otherwise it's grey
                         }
 


### PR DESCRIPTION
Les emails ne s'affichent pas dans Infomaniak. Sur infomaniak spécifiquement le css de l'email est mal interprété.
font-family='"Marianne", arial, sans-serif' les quotes dans les quotes cassent le css chez eux et donne pour résultat :
` font-family: "font-size:20px;font-weight:700;line-height:24px;text-align:left;color:#3a3a3a;`, et c'est donc la règle font-size: 0px utilisé par Mjml pour le système de colonne dans les emails qui est appliquée. Le texte ne s'affiche donc pas.