### PR TITLE
feat: check missions dates on every schema including missions

### DIFF
--- a/__tests__/test-create-member.ts
+++ b/__tests__/test-create-member.ts
@@ -114,7 +114,7 @@ describe("Test creating new user flow", () => {
             missions: [
                 {
                     start: new Date(),
-                    end: addMonth(new Date(), 4),
+                    end: addMonths(new Date(), 4),
                     startups: [newStartup.uuid],
                 },
             ],

--- a/__tests__/test-create-member.ts
+++ b/__tests__/test-create-member.ts
@@ -1,11 +1,12 @@
 import chai from "chai";
+import { addMonths } from "date-fns/addMonths";
 import { Selectable } from "kysely/dist/cjs/util/column-type";
 import { createMocks } from "node-mocks-http";
 import proxyquire from "proxyquire";
 import sinon from "sinon";
 
-import { testUsers } from "./utils/users-data";
 import utils from "./utils";
+import { testUsers } from "./utils/users-data";
 import { Incubators, Teams, Users } from "@/@types/db";
 import { db } from "@/lib/kysely";
 import { createMemberSchemaType } from "@/models/actions/member";
@@ -113,6 +114,7 @@ describe("Test creating new user flow", () => {
             missions: [
                 {
                     start: new Date(),
+                    end: addMonth(new Date(), 4),
                     startups: [newStartup.uuid],
                 },
             ],

--- a/src/models/actions/member.ts
+++ b/src/models/actions/member.ts
@@ -62,7 +62,7 @@ export const memberValidateInfoSchema = z.object({
     avatar: memberSchema.shape.avatar,
     github: memberSchema.shape.github,
     competences: memberSchema.shape.competences,
-    missions: memberSchema.shape.missions,
+    missions: memberSchema.shape.missions.superRefine(checkMissionsAreNotMoreThan6Months),
     domaine: memberSchema.shape.domaine,
     bio: memberSchema.shape.bio,
     memberType: memberSchema.shape.memberType,
@@ -110,7 +110,9 @@ export const createMemberSchema = z
                 .describe("Email"),
             domaine: memberSchema.shape.domaine,
         }),
-        missions: memberSchema.shape.missions,
+        missions: memberSchema.shape.missions.superRefine(
+            checkMissionsAreNotMoreThan6Months
+        ),
         incubator_id: z.string().uuid().optional(),
     })
     .refine(


### PR DESCRIPTION
On peut inviter un membre en mettant une date dans le futur à plus de 6 mois -> au moment de la changer ses infos il devra forcément changer.
Le membre peut mettre plus de 6 mois au moment de la validation des infos.