### PR TITLE
feat: handle user with mission starting in the futur

### DIFF
--- a/src/server/queueing/workers/send-validation-email.ts
+++ b/src/server/queueing/workers/send-validation-email.ts
@@ -26,15 +26,12 @@ export async function sendNewMemberValidationEmail(
     const data = SendNewMemberValidationEmailSchema.parse(job.data);
     const newMember = await getMemberIfValidOrThrowError(data.userId);
     const now = new Date();
+    // we fetch also startups for missions in the futur
     const userStartups = (await getUserStartups(data.userId)).filter(
         (startup) => {
-            return (
-                isAfter(now, startup.start ?? 0) &&
-                isBefore(now, startup.end ?? Infinity)
-            );
+            return isBefore(now, startup.end ?? Infinity);
         }
     );
-    // todo incubator_id might change to be another params send in object "job"
 
     const startupIncubatorIds = userStartups
         .map((startup) => startup.incubator_id)

--- a/src/server/schedulers/emailScheduler.ts
+++ b/src/server/schedulers/emailScheduler.ts
@@ -1,4 +1,6 @@
 import crypto, { randomBytes } from "crypto";
+import { isAfter } from "date-fns/isAfter";
+import { isBefore } from "date-fns/isBefore";
 import _ from "lodash/array";
 
 import betagouv from "../betagouv";
@@ -445,9 +447,14 @@ export async function sendOnboardingVerificationPendingEmail() {
     const dbUsers = (await getAllUsersInfo()).map((user) =>
         memberBaseInfoToModel(user)
     );
+    const now = new Date();
     const concernedUsers = dbUsers.filter(
         (user) =>
-            !utils.checkUserIsExpired(user) &&
+            user.missions.find(
+                (mission) =>
+                    isAfter(now, mission.start ?? 0) &&
+                    isBefore(now, mission.end ?? Infinity)
+            ) &&
             user.primary_email_status ===
                 EmailStatusCode.EMAIL_VERIFICATION_WAITING
     );


### PR DESCRIPTION
Fait :
- Envoye l'e-mail de validation à l'équipe même si la mission commence dans le futur
- Attend que la mission soit active pour envoyer l'e-mail de vérification au nouveau membre
- Envoye l'e-mail  "un nouveau membre dans votre équipe" à l'équipe même si la mission commence dans le futur

Pour plus tard éventuellement :
Une solution sympa mais qui demanderait un peu plus de changement serait d'utiliser la fonction schedule de pgboss. On pourrait ainsi envoyer l'email à l'équipe uniquement le jour de l'arrivée du/de la membre.
