### PR TITLE
chore: make verification waiting message clearer

### DIFF
--- a/src/components/MemberPage/MemberWaitingEmailValidationNotice.tsx
+++ b/src/components/MemberPage/MemberWaitingEmailValidationNotice.tsx
@@ -1,9 +1,9 @@
-import { getLastMissionDate } from "@/utils/member";
-import { fr } from "@codegouvfr/react-dsfr/fr";
-import Button from "@codegouvfr/react-dsfr/Button";
 import Alert from "@codegouvfr/react-dsfr/Alert";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { fr } from "@codegouvfr/react-dsfr/fr";
 
 import { MemberPageProps } from "./MemberPage";
+import { getLastMissionDate } from "@/utils/member";
 
 export const MemberWaitingEmailValidationNotice = ({
     userInfos,
@@ -12,7 +12,7 @@ export const MemberWaitingEmailValidationNotice = ({
 }) => (
     <Alert
         className={fr.cx("fr-mt-2w", "fr-mb-2w")}
-        title={`Email en attente de validation`}
+        title={`${userInfos.fullname} n'a pas encore activé son compte.`}
         severity="warning"
         description={
             <p>


### PR DESCRIPTION
Remplace le titre du message :
`Email en attente de validation` par
`John Tartenpion n'a pas activé sa fiche.`

message actuel:
<img width="1126" alt="Screenshot 2025-04-10 at 11 00 37" src="https://github.com/user-attachments/assets/12b3ce52-b0f1-4266-9f94-65fcbbc94e2a" />
