### PR TITLE
ci: codeql what setup on legacy master branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 13 * * 5'
 


### PR DESCRIPTION
@revolunet je ne suis pas sur de l'intérêt d'avoir codeQL et Sonar en même temps. Ils semblent se récouper sur quelques trucs. Je pense qu'on peut teste.