### PR TITLE
fix: remove list file that break when special caracter in filename

### DIFF
--- a/.github/workflows/onboarding-checklist-validation.yml
+++ b/.github/workflows/onboarding-checklist-validation.yml
@@ -27,12 +27,6 @@ jobs:
                 echo "Changed files:"
                 echo "$changed"
                 echo "changed_files=${changed//$'\n'/ }" >> "$GITHUB_OUTPUT"
-            - name: List changed files
-              run: |
-                echo "Changed files:"
-                for file in ${{ steps.changed-files.outputs.changed_files }}; do
-                  echo "- $file"
-                done
             - name: Check if cron or schedule file changed
               id: check_diff
               run: |


### PR DESCRIPTION
Retire le script qui listent les fichiers :
- le script précédent fait déjà la meme chose
- casse quand les fichiers utilisent des parenthèses