### PR TITLE
fix(a11y): fix broken links when parsing events content

### DIFF
--- a/src/app/(private)/(dashboard)/events/page.tsx
+++ b/src/app/(private)/(dashboard)/events/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import ical from "node-ical";
 
-import { EventsList } from "@/components/EventsList";
+import { EventsList } from "@/components/EventsList/EventsList";
 import { authOptions } from "@/utils/authoptions";
 import { routeTitles } from "@/utils/routes/routeTitles";
 

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -2,13 +2,30 @@ import { fr } from "@codegouvfr/react-dsfr";
 import Card from "@codegouvfr/react-dsfr/Card";
 import { format } from "date-fns";
 import { fr as frLocale } from "date-fns/locale/fr";
+import MarkdownIt from "markdown-it";
 import { CalendarResponse } from "node-ical";
+
+// function htmlize(str = "") {
+//     return str
+//         .replace(/^(https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`)
+//         .replace(/[^="'](https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`);
+// }
 
 function htmlize(str = "") {
     return str
         .replace(/^(https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`)
         .replace(/[^="'](https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`);
 }
+
+const mdParser = new MarkdownIt({
+    html: true,
+});
+
+mdParser.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    tokens[idx].attrPush(["class", "fr-link"]); // Add class
+    tokens[idx].attrPush(["target", "_blank"]); // Add class
+    return self.renderToken(tokens, idx, options);
+};
 
 export function EventsList({ events }: { events: CalendarResponse }) {
     const href = "";
@@ -58,7 +75,7 @@ export function EventsList({ events }: { events: CalendarResponse }) {
                                     whiteSpace: "break-spaces",
                                 }}
                                 dangerouslySetInnerHTML={{
-                                    __html: htmlize(event.description),
+                                    __html: mdParser.renderInline(event.description),
                                 }}
                             />
                         }
@@ -81,7 +98,7 @@ export function EventsList({ events }: { events: CalendarResponse }) {
                                         whiteSpace: "break-spaces",
                                     }}
                                     dangerouslySetInnerHTML={{
-                                        __html: `📍 ${htmlize(event.location)}`,
+                                        __html: `📍 ${mdParser.renderInline(event.location)}`,
                                     }}
                                 />
                             ) : null

--- a/src/components/EventsList/EventsList.css
+++ b/src/components/EventsList/EventsList.css
@@ -1,0 +1,3 @@
+#events-list .fr-card__detail .fr-link--sm {
+    font-size: 0.75rem;
+}

--- a/src/components/EventsList/EventsList.tsx
+++ b/src/components/EventsList/EventsList.tsx
@@ -4,25 +4,20 @@ import { format } from "date-fns";
 import { fr as frLocale } from "date-fns/locale/fr";
 import MarkdownIt from "markdown-it";
 import { CalendarResponse } from "node-ical";
-
-// function htmlize(str = "") {
-//     return str
-//         .replace(/^(https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`)
-//         .replace(/[^="'](https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`);
-// }
-
-function htmlize(str = "") {
-    return str
-        .replace(/^(https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`)
-        .replace(/[^="'](https:\/\/[^\s\n]+)/g, `<a href="$1">$1</a>`);
-}
+import "./EventsList.css";
 
 const mdParser = new MarkdownIt({
     html: true,
+    linkify: true,
+    highlight: function (str) { 
+        console.log(str)
+        return '';
+    }
+
 });
 
 mdParser.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-    tokens[idx].attrPush(["class", "fr-link"]); // Add class
+    tokens[idx].attrPush(["class", "fr-link--sm"]); // Add class
     tokens[idx].attrPush(["target", "_blank"]); // Add class
     return self.renderToken(tokens, idx, options);
 };
@@ -55,7 +50,7 @@ export function EventsList({ events }: { events: CalendarResponse }) {
         );
 
     return (
-        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+        <div id="events-list" className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
             {sortedEvents.map(([key, event]) => {
                 if (event.type !== "VEVENT") {
                     return null;
@@ -75,7 +70,7 @@ export function EventsList({ events }: { events: CalendarResponse }) {
                                     whiteSpace: "break-spaces",
                                 }}
                                 dangerouslySetInnerHTML={{
-                                    __html: mdParser.renderInline(event.description),
+                                    __html: mdParser.renderInline(event.description || ""),
                                 }}
                             />
                         }
@@ -98,7 +93,7 @@ export function EventsList({ events }: { events: CalendarResponse }) {
                                         whiteSpace: "break-spaces",
                                     }}
                                     dangerouslySetInnerHTML={{
-                                        __html: `📍 ${mdParser.renderInline(event.location)}`,
+                                        __html: `📍 ${mdParser.renderInline(event.location || "")}`,
                                     }}
                                 />
                             ) : null


### PR DESCRIPTION
sur staging il reste un "<a href" qui apparait comme du texte peut être qu'on pourra faire un replace(" ","") pour ce cas precis, j'ai pas réussi à trouver quelques chose qui corriger de façon générique.