### PR TITLE
fix(schedule.ts): cron should not execute every monday every 3 months

### DIFF
--- a/src/server/queueing/schedule.ts
+++ b/src/server/queueing/schedule.ts
@@ -11,12 +11,12 @@ export type PgBossJobType = {
 export const pgBossJobs: PgBossJobType[] = [
     {
         topic: sendEmailToTeamsToCheckOnTeamCompositionTopic,
-        frequency: `0 8 1,2,3,4,5,6,7 */3 1`,
+        frequency: `0 8 1 */3 *`,
         description: `Envoie un email aux équipes produits pour qu'ils vérifient la composition de leur équipe`,
     },
     {
         topic: sendEmailToIncubatorTeamTopic,
-        frequency: `0 8 1,2,3,4,5,6,7 */3 1`,
+        frequency: `0 8 1 */3 *`,
         description: `Envoie un email aux équipes incubateur pour qu'ils vérifient les produits qui n'ont pas changé depuis X mois`,
     },
 ];


### PR DESCRIPTION
Dans Vixie cron (utilisé sur Linux, crontab classique), si à la fois jour_du_mois ET jour_de_la_semaine sont définis, le cron s’exécute si l’un OU l’autre correspond.
Dans 0 8 1,2,3,4,5,6,7 */3 1, le cron au lieu de s'éxécuter le lundi et si le jour 1,2,3,4,5,6,ou 7 du mois, le cron s'éxécute le lundi ou le 1,2,3,4,5,6 ou 7 du mois.
Quick fix : on envoie que le le 1er du mois.