### PR TITLE
fix(formations): allow empty descriptions

### DIFF
--- a/src/models/formation.ts
+++ b/src/models/formation.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const formationSchema = z.object({
   id: z.string(),
   airtable_id: z.string(),
-  description: z.string(),
+  description: z.string().optional(),
   name: z.string(),
   imageUrl: z.string().optional(),
   created_at: z.date(),


### PR DESCRIPTION
Il y a actuellement une exception lorsque la description de la formation n'est pas saisie

https://espace-membre.incubateur.net/formations