### PR TITLE
feat: add support info for OPI emails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7337,9 +7337,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001700",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/components/BadgeEmailPlan.tsx
+++ b/src/components/BadgeEmailPlan.tsx
@@ -22,9 +22,25 @@ export const BadgeEmailPlan = ({ plan }: { plan: EMAIL_PLAN_TYPE }) => {
       </Badge>
     ))
     .with(EMAIL_PLAN_TYPE.EMAIL_PLAN_OPI, () => (
-      <Badge small className={fr.cx("fr-ml-1w")} severity="info" as="span">
-        Suite numérique
-      </Badge>
+      <>
+        <Badge small className={fr.cx("fr-ml-1w")} severity="info" as="span">
+          Suite numérique
+        </Badge>
+        <a
+          title="Envoyer un email à support-messagerie@mail.numerique.gouv.fr"
+          href="mailto:support-messagerie@mail.numerique.gouv.fr"
+          style={{ backgroundImage: "none" }}
+        >
+          <Badge
+            small
+            className={fr.cx("fr-ml-1w", "ri-question-fill")}
+            severity="new"
+            as="span"
+          >
+            Contacter le support par email
+          </Badge>
+        </a>
+      </>
     ))
     .exhaustive();
 };


### PR DESCRIPTION
Visible à deux endroits :

Accueil fiche membre :
<img width="584" height="130" alt="Capture d’écran 2025-09-15 à 12 36 32" src="https://github.com/user-attachments/assets/b893e099-485f-4a34-a333-082589a22e80" />

Onglet "Compte email":
<img width="886" height="155" alt="Capture d’écran 2025-09-15 à 12 35 41" src="https://github.com/user-attachments/assets/b8a7952a-32dd-408c-ad5c-cdb973d977a5" />
