### PR TITLE
feat: startups urls

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -17,16 +17,12 @@ fileignoreconfig:
   checksum: 6f1851774271e3f0d3fcdf1feac4cd6ba03f6e75922fd839a94b276589a77b76
 - filename: src/app/(private)/(dashboard)/services/page.tsx
   checksum: daebae004c8c06af9a88aaf57a1fad4b0a6efcb7920cf9628e0c1fd1985569ab
-- filename: src/components/Checklist.tsx
-  checksum: 7bcd2b7b8aa2c603855af404f89c24d9bb02ba6e7b4a2a8503ef7b1b72902178
-- filename: src/components/EventsList/EventsList.tsx
-  checksum: 01f943fd703c4c5d4e3298bb73487c482b8aa789be160f0ba9421b29102f7a00
 - filename: src/components/MemberPage/MemberWaitingValidationNotice.tsx
   checksum: 4243d7f9fb28db14113849647ba3126d456aa935c7169722d844ae11b3d06443
-- filename: src/components/StartupListPage/StartupList.tsx
-  checksum: e80ba5ef4992ffe38f37e645f86acdcc35d4e19742a2b4765e6d2a26d739b1d7
-- filename: src/components/StartupPage/StartupHeader.tsx
-  checksum: eadc2f2e6e18c331613266eab493ddac385b8fa083d0f4ad21596b89b2cf59ab
+- filename: src/components/StartupForm/StartupUrlsEditor.tsx
+  checksum: 81ac53ab5b6e4920711dbfe00c18126fb5462ca51be580612e39adb0ebcda498
+- filename: src/components/StartupPage/StartupDescription.tsx
+  checksum: cde3721f491f630ab6ba020833fa2e4cc96dbabb289e74f7fe14f37ff8d75679
 - filename: src/components/StartupPage/StartupMembers.tsx
   checksum: 6a20aba25aa570f49f0413babcb256d1db870522851f2e865088df7fe6e583a9
 - filename: src/lib/dimail/client.spec.ts
@@ -37,6 +33,8 @@ fileignoreconfig:
   checksum: a74621f69d4d7e4cdb99c05d127fcdc4a3f81aed2dc921146272f3deed3e283e
 - filename: src/models/misc.ts
   checksum: 0294a10f151fe53549f7bdfd6081d5a69d7572bb633b7813adc49bfac2f2f241
+- filename: src/scripts/update-local-files.ts
+  checksum: 244a3c61ec97d559e073b13d0c076cbfb4b564aafa09cc23a0c0ed5c898260b0
 - filename: src/server/queueing/workers/create-dimail-mailbox.spec.ts
   checksum: 7961ed68360545e4e2c72bf9884e12943467175bdeed35b38bfc177613fc0b15
 - filename: src/server/queueing/workers/send-verification-email.ts

--- a/migrations/20260314120000_create_startup_urls_table.ts
+++ b/migrations/20260314120000_create_startup_urls_table.ts
@@ -1,0 +1,86 @@
+const URL_COLUMN_TYPE_MAP = [
+  { column: "link", type: "website" },
+  { column: "repository", type: "repository" },
+  { column: "stats_url", type: "stats" },
+  { column: "budget_url", type: "budget" },
+  { column: "roadmap_url", type: "roadmap" },
+  { column: "dashlord_url", type: "dashlord" },
+  { column: "ecodesign_url", type: "ecodesign" },
+  { column: "tech_audit_url", type: "tech_audit" },
+  { column: "impact_url", type: "impact" },
+  { column: "analyse_risques_url", type: "analyse_risques" },
+];
+
+export async function up(knex) {
+  await knex.schema.createTable("startup_urls", (table) => {
+    table.uuid("uuid").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("startup_uuid")
+      .notNullable()
+      .references("uuid")
+      .inTable("startups")
+      .onDelete("CASCADE");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.timestamp("updated_at").defaultTo(knex.fn.now());
+    table.text("label").nullable();
+    table.text("type").notNullable();
+    table.text("url").notNullable();
+    table.index(["startup_uuid"]);
+  });
+
+  // Migrate existing URL columns into startup_urls
+  for (const { column, type } of URL_COLUMN_TYPE_MAP) {
+    await knex.raw(
+      `
+      INSERT INTO startup_urls (startup_uuid, type, url)
+      SELECT uuid, ?, ${column}
+      FROM startups
+      WHERE ${column} IS NOT NULL AND ${column} != ''
+    `,
+      [type],
+    );
+  }
+
+  // Drop migrated URL columns from startups
+  //await knex.schema.alterTable("startups", (table) => {
+  // table.dropColumn("link");
+  // table.dropColumn("repository");
+  // table.dropColumn("stats_url");
+  // table.dropColumn("budget_url");
+  // table.dropColumn("roadmap_url");
+  // table.dropColumn("dashlord_url");
+  // table.dropColumn("ecodesign_url");
+  // table.dropColumn("tech_audit_url");
+  // table.dropColumn("impact_url");
+  // table.dropColumn("analyse_risques_url");
+  // });
+}
+
+export async function down(knex) {
+  // await knex.schema.alterTable("startups", (table) => {
+  // table.text("link").nullable();
+  // table.text("repository").nullable();
+  // table.text("stats_url").nullable();
+  // table.text("budget_url").nullable();
+  // table.text("roadmap_url").nullable();
+  // table.text("dashlord_url").nullable();
+  // table.text("ecodesign_url").nullable();
+  // table.text("tech_audit_url").nullable();
+  // table.text("impact_url").nullable();
+  // table.text("analyse_risques_url").nullable();
+  //});
+
+  // for (const { column, type } of URL_COLUMN_TYPE_MAP) {
+  //   await knex.raw(
+  //     `
+  //     UPDATE startups s
+  //     SET ${column} = su.url
+  //     FROM startup_urls su
+  //     WHERE su.startup_uuid = s.uuid AND su.type = ?
+  //   `,
+  //     [type],
+  //   );
+  // }
+
+  await knex.schema.dropTableIfExists("startup_urls");
+}

--- a/src/@types/db.d.ts
+++ b/src/@types/db.d.ts
@@ -460,6 +460,16 @@ export interface StartupsOrganizations {
   uuid: Generated<string>;
 }
 
+export interface StartupUrls {
+  created_at: Generated<Timestamp | null>;
+  label: string | null;
+  startup_uuid: string;
+  type: string;
+  updated_at: Generated<Timestamp | null>;
+  url: string;
+  uuid: Generated<string>;
+}
+
 export interface Tasks {
   created_at: Generated<Timestamp>;
   description: string | null;
@@ -563,6 +573,7 @@ export interface DB {
   sessions: Sessions;
   startup_aggregated_stats: StartupAggregatedStats;
   startup_events: StartupEvents;
+  startup_urls: StartupUrls;
   startups: Startups;
   startups_files: StartupsFiles;
   startups_organizations: StartupsOrganizations;

--- a/src/app/(private)/(dashboard)/startups/[id]/info-form/page.tsx
+++ b/src/app/(private)/(dashboard)/startups/[id]/info-form/page.tsx
@@ -12,7 +12,7 @@ import { getStartup } from "@/lib/kysely/queries";
 import s3 from "@/lib/s3";
 import { startupChangeToModel, startupToModel } from "@/models/mapper";
 import { sponsorSchema } from "@/models/sponsor";
-import { eventSchema, phaseSchema } from "@/models/startup";
+import { eventSchema, phaseSchema, startupUrlSchema } from "@/models/startup";
 import { authOptions } from "@/utils/authoptions";
 import { routeTitles } from "@/utils/routes/routeTitles";
 
@@ -100,6 +100,15 @@ export default async function Page(props) {
         .selectAll()
         .execute(),
     );
+  const startupUrls = z
+    .array(startupUrlSchema)
+    .parse(
+      await db
+        .selectFrom("startup_urls")
+        .where("startup_uuid", "=", startup.uuid)
+        .selectAll()
+        .execute(),
+    );
   const s3ShotKey = `startups/${startup.ghid}/shot.jpg`;
   let hasShot = false;
   try {
@@ -132,6 +141,7 @@ export default async function Page(props) {
     startupSponsors,
     startupPhases,
     startupEvents,
+    startupUrls,
     heroURL: hasHero
       ? `/api/image?fileObjIdentifier=${startup.ghid}&fileRelativeObjType=startup&fileIdentifier=hero`
       : undefined,

--- a/src/app/(private)/(dashboard)/startups/[id]/page.tsx
+++ b/src/app/(private)/(dashboard)/startups/[id]/page.tsx
@@ -108,6 +108,11 @@ export default async function Page({ params }: Props) {
     .selectAll()
     .execute();
   const startup = startupToModel(dbSe);
+  const startupUrls = await db
+    .selectFrom("startup_urls")
+    .where("startup_uuid", "=", dbSe.uuid)
+    .selectAll()
+    .execute();
   const startupMembers = (await getUsersByStartup(dbSe.uuid)).map((user) => {
     return memberBaseInfoToModel(user);
   });
@@ -140,6 +145,7 @@ export default async function Page({ params }: Props) {
         allMembers={allMembers}
         changes={changes.map((change) => startupChangeToModel(change))}
         startupInfos={startup}
+        startupUrls={startupUrls}
         incubator={incubator}
         sponsors={sponsors}
         sentryTeams={sentryTeams}

--- a/src/app/api/startups/actions.ts
+++ b/src/app/api/startups/actions.ts
@@ -36,6 +36,7 @@ export async function getStartup({ uuid }: { uuid: string }) {
 export async function createStartup({
   formData: {
     startup,
+    startup_urls,
     startupSponsors,
     startupEvents,
     startupPhases,
@@ -45,6 +46,7 @@ export async function createStartup({
 }: {
   formData: {
     startup: startupInfoUpdateSchemaType["startup"];
+    startup_urls: startupInfoUpdateSchemaType["startup_urls"];
     startupEvents: startupInfoUpdateSchemaType["startupEvents"];
     startupPhases: startupInfoUpdateSchemaType["startupPhases"];
     startupSponsors: startupInfoUpdateSchemaType["startupSponsors"];
@@ -81,6 +83,21 @@ export async function createStartup({
       }
 
       const startupUuid = res.uuid;
+
+      // Insert startup_urls
+      if (startup_urls && startup_urls.length) {
+        await trx
+          .insertInto("startup_urls")
+          .values(
+            startup_urls.map((u) => ({
+              startup_uuid: startupUuid,
+              type: u.type,
+              label: u.label ?? null,
+              url: u.url,
+            })),
+          )
+          .execute();
+      }
 
       // Create new sponsors
       for (const newSponsor of newSponsors) {
@@ -134,7 +151,7 @@ export async function createStartup({
         .where("startup_id", "=", startupUuid)
         .execute();
 
-      if (startupEvents.length) {
+      if (startupEvents && startupEvents.length) {
         await trx
           .insertInto("startup_events")
           .values(
@@ -184,6 +201,7 @@ export async function createStartup({
 export async function updateStartup({
   formData: {
     startup,
+    startup_urls,
     startupSponsors,
     startupPhases,
     startupEvents,
@@ -193,6 +211,7 @@ export async function updateStartup({
 }: {
   formData: {
     startup: startupInfoUpdateSchemaType["startup"];
+    startup_urls: startupInfoUpdateSchemaType["startup_urls"];
     startupEvents: startupInfoUpdateSchemaType["startupEvents"];
     startupPhases: startupInfoUpdateSchemaType["startupPhases"];
     startupSponsors: startupInfoUpdateSchemaType["startupSponsors"];
@@ -262,6 +281,25 @@ export async function updateStartup({
       .where("uuid", "=", startupUuid)
       .returning(["uuid", "ghid"])
       .executeTakeFirstOrThrow();
+
+    // replace startup_urls
+    await trx
+      .deleteFrom("startup_urls")
+      .where("startup_uuid", "=", startupUuid)
+      .execute();
+    if (startup_urls && startup_urls.length) {
+      await trx
+        .insertInto("startup_urls")
+        .values(
+          startup_urls.map((u) => ({
+            startup_uuid: startupUuid,
+            type: u.type,
+            label: u.label ?? null,
+            url: u.url,
+          })),
+        )
+        .execute();
+    }
 
     // create new sponsors
     for (const newSponsor of newSponsors) {
@@ -344,7 +382,7 @@ export async function updateStartup({
       .where("startup_id", "=", startupUuid)
       .execute();
 
-    if (startupEvents.length) {
+    if (startupEvents && startupEvents.length) {
       await trx
         .insertInto("startup_events")
         .values(

--- a/src/components/StartupForm/StartupForm.tsx
+++ b/src/components/StartupForm/StartupForm.tsx
@@ -17,6 +17,7 @@ import { EventsEditor } from "./EventsEditor";
 import MdEditorCustomHeaderPlugin from "./MdEditorCustomHeaderPlugin";
 import { PhasesEditor } from "./PhasesEditor";
 import SponsorBlock from "./SponsorBlock";
+import { StartupUrlsEditor } from "./StartupUrlsEditor";
 import { TechnoEditor } from "./TechnoEditor";
 import { ThematiquesEditor } from "./ThematiquesEditor";
 import { UsertypesEditor } from "./UsertypesEditor";
@@ -37,8 +38,10 @@ import {
   eventSchemaType,
   phaseSchemaType,
   startupSchemaType,
+  startupUrlSchemaType,
 } from "@/models/startup";
 
+//@ts-ignore
 import "react-markdown-editor-lite/lib/index.css";
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -85,6 +88,7 @@ export interface StartupFormProps {
   startupSponsors?: sponsorSchemaType[];
   startupPhases?: phaseSchemaType[];
   startupEvents?: eventSchemaType[];
+  startupUrls?: startupUrlSchemaType[];
   incubatorOptions: Option[];
   sponsorOptions: Option[];
   save: (data: startupInfoUpdateSchemaType) => Promise<ActionResponse>;
@@ -138,6 +142,7 @@ export function StartupForm(props: StartupFormProps) {
     mode: "onChange",
     defaultValues: {
       startup: props.startup || NEW_PRODUCT_DATA,
+      startup_urls: props.startupUrls || [],
       startupSponsors: (props.startupSponsors || []).map((s) => s.uuid),
       startupPhases: props.startupPhases || [
         {
@@ -266,7 +271,6 @@ export function StartupForm(props: StartupFormProps) {
             placeholder="ex: contact@[startup].beta.gouv.fr"
             hintText={`Préférer un email générique plutôt que le mail d'une personne de l'équipe.`}
           />
-          <BasicInput id="link" />
           <Checkbox
             options={[
               {
@@ -554,13 +558,15 @@ export function StartupForm(props: StartupFormProps) {
           {/*[FILE UPLOAD ]<hr />*/}
 
           <h2>Liens</h2>
-          <BasicInput id="stats_url" />
-          <BasicInput id="impact_url" />
-          <BasicInput id="budget_url" />
-          <BasicInput id="roadmap_url" />
-          <BasicInput id="repository" />
-          <BasicInput id="dashlord_url" />
-          <BasicInput id="ecodesign_url" />
+          <p>
+            Tous les liens utiles pour ce produit. Ex: Projets GitHub,
+            documentations, Site web, Liens vers des démos...
+          </p>
+          <StartupUrlsEditor
+            control={control as any}
+            register={register as any}
+            errors={errors.startup_urls as any}
+          />
 
           <Button
             className={fr.cx("fr-mt-3w")}

--- a/src/components/StartupForm/StartupUrlsEditor.css
+++ b/src/components/StartupForm/StartupUrlsEditor.css
@@ -1,0 +1,9 @@
+.table-xs-col-last thead th:first-child {
+  width: 250px;
+}
+.table-xs-col-last thead th:nth-child(2) {
+  width: 250px;
+}
+.table-xs-col-last thead th:last-child {
+  width: 100px;
+}

--- a/src/components/StartupForm/StartupUrlsEditor.tsx
+++ b/src/components/StartupForm/StartupUrlsEditor.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+
+import { fr } from "@codegouvfr/react-dsfr";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Select } from "@codegouvfr/react-dsfr/Select";
+import Table from "@codegouvfr/react-dsfr/Table";
+import {
+  Control,
+  useFieldArray,
+  useWatch,
+  UseFormRegister,
+} from "react-hook-form";
+
+import { STARTUP_URL_TYPES, STARTUP_URL_TYPE_LABELS } from "@/models/startup";
+import { startupInfoUpdateSchemaType } from "@/models/actions/startup";
+
+import "./StartupUrlsEditor.css";
+
+export type HasStartupUrls<T = any> = T & {
+  startup_urls: startupInfoUpdateSchemaType["startup_urls"];
+};
+
+export function StartupUrlsEditor({
+  control,
+  errors,
+  register,
+}: {
+  control: Control<HasStartupUrls>;
+  errors?: Record<string, any>[];
+  register: UseFormRegister<HasStartupUrls>;
+}) {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "startup_urls",
+  });
+
+  useWatch({ control, name: "startup_urls" });
+
+  return (
+    <div className={fr.cx("fr-mb-3w")}>
+      <Table
+        fixed
+        className="table-xs-col-last"
+        style={{ marginBottom: "0.5rem" }}
+        headers={["Type", "Label (optionnel)", "URL", "Action"]}
+        data={fields.map((field, index) => [
+          <Select
+            key={field.id + "-type"}
+            label={undefined}
+            nativeSelectProps={register(`startup_urls.${index}.type`)}
+          >
+            {STARTUP_URL_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {STARTUP_URL_TYPE_LABELS[type]}
+              </option>
+            ))}
+          </Select>,
+          <Input
+            label={null}
+            key={field.id + "-label"}
+            nativeInputProps={{
+              placeholder: "Ex: Version bêta",
+              ...register(`startup_urls.${index}.label`),
+            }}
+            state={errors?.[index]?.label ? "error" : "default"}
+            stateRelatedMessage={errors?.[index]?.label?.message}
+          />,
+          <Input
+            label={null}
+            key={field.id + "-url"}
+            nativeInputProps={{
+              placeholder: "https://...",
+              type: "url",
+              ...register(`startup_urls.${index}.url`),
+            }}
+            state={errors?.[index]?.url ? "error" : "default"}
+            stateRelatedMessage={errors?.[index]?.url?.message}
+          />,
+          <button
+            key={field.id + "-remove"}
+            className={fr.cx("fr-icon-delete-bin-line")}
+            style={{ cursor: "pointer", float: "right" }}
+            type="button"
+            onClick={() => remove(index)}
+            title={`Supprimer ce lien`}
+          />,
+        ])}
+      />
+      <Button
+        iconId="fr-icon-add-circle-line"
+        priority="secondary"
+        size="small"
+        type="button"
+        onClick={() => append({ type: "website", label: null, url: "" })}
+      >
+        Ajouter un lien
+      </Button>
+    </div>
+  );
+}

--- a/src/components/StartupInfoCreatePage/StartupInfoCreate.tsx
+++ b/src/components/StartupInfoCreatePage/StartupInfoCreate.tsx
@@ -26,6 +26,7 @@ export const StartupInfoCreate = (props: StartupInfoCreateProps) => {
       const res = await safeCreateStartup({
         formData: {
           startup: data.startup,
+          startup_urls: data.startup_urls,
           startupEvents: data.startupEvents,
           startupPhases: data.startupPhases,
           startupSponsors: data.startupSponsors,

--- a/src/components/StartupInfoUpdatePage/StartupInfoUpdate.tsx
+++ b/src/components/StartupInfoUpdatePage/StartupInfoUpdate.tsx
@@ -15,6 +15,7 @@ import {
   eventSchemaType,
   phaseSchemaType,
   startupSchemaType,
+  startupUrlSchemaType,
 } from "@/models/startup";
 import { StartupChangeSchemaType } from "@/models/startupChange";
 import { saveImage } from "@/utils/file";
@@ -25,6 +26,7 @@ interface StartupInfoUpdateProps {
   startupSponsors: sponsorSchemaType[];
   startupPhases: phaseSchemaType[];
   startupEvents: eventSchemaType[];
+  startupUrls: startupUrlSchemaType[];
   incubatorOptions: Option[];
   sponsorOptions: Option[];
   heroURL?: string;
@@ -43,6 +45,7 @@ export const StartupInfoUpdate = (props: StartupInfoUpdateProps) => {
       const res = await safeUpdateStartup({
         formData: {
           startup: data.startup,
+          startup_urls: data.startup_urls,
           startupEvents: data.startupEvents,
           startupPhases: data.startupPhases,
           startupSponsors: data.startupSponsors,
@@ -120,6 +123,7 @@ export const StartupInfoUpdate = (props: StartupInfoUpdateProps) => {
             startupSponsors={props.startupSponsors}
             startupPhases={props.startupPhases}
             startupEvents={props.startupEvents}
+            startupUrls={props.startupUrls}
             startup={props.startup}
             heroURL={props.heroURL}
             shotURL={props.shotURL}

--- a/src/components/StartupPage/StartupDescription.tsx
+++ b/src/components/StartupPage/StartupDescription.tsx
@@ -1,14 +1,17 @@
 import { Table } from "@codegouvfr/react-dsfr/Table";
 import MarkdownIt from "markdown-it";
 
-import { startupSchemaType } from "@/models/startup";
+import { StartupUrlRow } from "./StartupPage";
+import { STARTUP_URL_TYPE_LABELS, startupSchemaType } from "@/models/startup";
 
 const mdParser = new MarkdownIt(/* Markdown-it options */);
 
 export const StartupDescription = ({
   startupInfos,
+  startupUrls,
 }: {
   startupInfos: startupSchemaType;
+  startupUrls: StartupUrlRow[];
 }) => {
   return (
     <>
@@ -19,12 +22,6 @@ export const StartupDescription = ({
             "Contact",
             <a key="4" href={`mailto:${startupInfos.contact}`}>
               {startupInfos.contact}
-            </a>,
-          ],
-          startupInfos.link && [
-            "URL du produit",
-            <a key="1" href={startupInfos.link} target="_blank">
-              {startupInfos.link}
             </a>,
           ],
           [
@@ -38,48 +35,18 @@ export const StartupDescription = ({
               {startupInfos.ghid}
             </a>,
           ],
-          startupInfos.repository && [
-            "Code source",
-            <a key="3" href={startupInfos.repository} target="_blank">
-              {startupInfos.repository}
-            </a>,
-          ],
-          startupInfos.stats_url && [
-            "Statistiques d'usage",
-            <a key="5" href={startupInfos.stats_url} target="_blank">
-              {startupInfos.stats_url}
-            </a>,
-          ],
-          startupInfos.impact_url && [
-            "Matrice d'impact",
-            <a key="6" href={startupInfos.impact_url} target="_blank">
-              {startupInfos.impact_url}
-            </a>,
-          ],
-          startupInfos.budget_url && [
-            "Budget",
-            <a key="7" href={startupInfos.budget_url} target="_blank">
-              {startupInfos.budget_url}
-            </a>,
-          ],
-          startupInfos.roadmap_url && [
-            "Roadmap",
-            <a key="8" href={startupInfos.roadmap_url} target="_blank">
-              {startupInfos.roadmap_url}
-            </a>,
-          ],
-          startupInfos.dashlord_url && [
-            "Rapport DashLord",
-            <a key="9" href={startupInfos.dashlord_url} target="_blank">
-              {startupInfos.dashlord_url}
-            </a>,
-          ],
-          startupInfos.ecodesign_url && [
-            "Déclaration d'écoconception",
-            <a key="11" href={startupInfos.ecodesign_url} target="_blank">
-              {startupInfos.ecodesign_url}
-            </a>,
-          ],
+          ...startupUrls
+            .filter((u) => u.url)
+            .map((u, i) => [
+              u.label ||
+                STARTUP_URL_TYPE_LABELS[
+                  u.type as keyof typeof STARTUP_URL_TYPE_LABELS
+                ] ||
+                u.type,
+              <a key={`url-${i}`} href={u.url} target="_blank">
+                {u.url}
+              </a>,
+            ]),
           startupInfos.techno &&
             startupInfos.techno.length && [
               "Technologies",

--- a/src/components/StartupPage/StartupHeader.tsx
+++ b/src/components/StartupPage/StartupHeader.tsx
@@ -2,7 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr/fr";
 import { Tag } from "@codegouvfr/react-dsfr/Tag";
 
 import { BadgePhase } from "./BadgePhase";
-import { StartupPageProps } from "./StartupPage";
+import { StartupPageProps, StartupUrlRow } from "./StartupPage";
 import { StartupPhase } from "@/models/startup";
 import { createSerializer } from "nuqs";
 import { startupsQueryParser } from "../StartupListPage/utils";
@@ -13,13 +13,15 @@ const serialize = createSerializer({
 
 export function StartupHeader({
   startupInfos,
+  startupUrls,
   incubator,
   sponsors,
   currentPhase,
 }: Pick<
   StartupPageProps,
-  "startupInfos" | "changes" | "incubator" | "sponsors"
-> & { currentPhase: StartupPhase | null }) {
+  "startupInfos" | "startupUrls" | "changes" | "incubator" | "sponsors"
+> & { currentPhase: string | null }) {
+  const websiteUrl = startupUrls.find((u) => u.type === "website")?.url;
   return (
     <>
       <div className={fr.cx("fr-col-12")}>
@@ -34,16 +36,10 @@ export function StartupHeader({
         </div>
       </div>
       <div className={fr.cx("fr-col-12")}>
-        {currentPhase && (
-          <BadgePhase phase={currentPhase} className={fr.cx("fr-mr-2w")} />
-        )}
-        {startupInfos.link && (
-          <a
-            target="_blank"
-            href={startupInfos.link}
-            className={fr.cx("fr-mr-2w")}
-          >
-            {startupInfos.link}
+        <BadgePhase phase={currentPhase} className={fr.cx("fr-mr-2w")} />
+        {websiteUrl && (
+          <a target="_blank" href={websiteUrl} className={fr.cx("fr-mr-2w")}>
+            {websiteUrl}
           </a>
         )}
       </div>

--- a/src/components/StartupPage/StartupPage.tsx
+++ b/src/components/StartupPage/StartupPage.tsx
@@ -26,8 +26,17 @@ import { getCurrentPhase } from "@/utils/startup";
 //@ts-ignore
 import "./timeline.css";
 
+export interface StartupUrlRow {
+  uuid: string;
+  startup_uuid: string;
+  label: string | null;
+  type: string;
+  url: string;
+}
+
 export interface StartupPageProps {
   startupInfos: startupSchemaType;
+  startupUrls: StartupUrlRow[];
   allMembers: {
     fullname: string;
     username: string;
@@ -61,6 +70,7 @@ export interface StartupPageProps {
 
 export default function StartupPage({
   startupInfos,
+  startupUrls,
   members,
   allMembers,
   phases,
@@ -114,7 +124,7 @@ export default function StartupPage({
       label: "Description",
       tabId: "description",
       isDefault: hash === "description",
-      content: <StartupDescription startupInfos={startupInfos} />,
+      content: <StartupDescription startupInfos={startupInfos} startupUrls={startupUrls} />,
     },
     {
       label: "Historique",
@@ -146,6 +156,7 @@ export default function StartupPage({
       />
       <StartupHeader
         startupInfos={startupInfos}
+        startupUrls={startupUrls}
         changes={changes}
         incubator={incubator}
         sponsors={sponsors}

--- a/src/models/actions/startup.ts
+++ b/src/models/actions/startup.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 
 import { sponsorSchema } from "../sponsor";
 import { FileType } from "@/lib/file";
-import { eventSchema, phaseSchema, startupSchema } from "@/models/startup";
+import {
+  eventSchema,
+  phaseSchema,
+  startupSchema,
+  startupUrlSchema,
+} from "@/models/startup";
 
 export const startupInfoUpdateSchema = z.object({
   startup: z.object({
@@ -10,15 +15,9 @@ export const startupInfoUpdateSchema = z.object({
     pitch: startupSchema.shape.pitch,
     incubator_id: startupSchema.shape.incubator_id,
     contact: startupSchema.shape.contact,
-    link: startupSchema.shape.link,
-    repository: startupSchema.shape.repository,
     accessibility_status: startupSchema.shape.accessibility_status,
-    dashlord_url: startupSchema.shape.dashlord_url,
-    stats_url: startupSchema.shape.stats_url,
-    budget_url: startupSchema.shape.budget_url,
     mon_service_securise: startupSchema.shape.mon_service_securise,
     analyse_risques: startupSchema.shape.analyse_risques,
-    analyse_risques_url: startupSchema.shape.analyse_risques_url,
     //  events: startupSchema.shape.events,
     techno: startupSchema.shape.techno,
     usertypes: startupSchema.shape.usertypes,
@@ -29,11 +28,8 @@ export const startupInfoUpdateSchema = z.object({
     has_mobile_app: startupSchema.shape.has_mobile_app,
     is_private_url: startupSchema.shape.is_private_url,
     dsfr_status: startupSchema.shape.dsfr_status,
-    tech_audit_url: startupSchema.shape.tech_audit_url,
-    roadmap_url: startupSchema.shape.roadmap_url,
-    ecodesign_url: startupSchema.shape.ecodesign_url,
-    impact_url: startupSchema.shape.impact_url,
   }),
+  startup_urls: z.array(startupUrlSchema),
   shot: z
     .instanceof(FileType)
     .refine((file) => file.size > 0, "File is required")

--- a/src/models/mapper/startupMapper.ts
+++ b/src/models/mapper/startupMapper.ts
@@ -24,7 +24,6 @@ export function startupToModel(
     usertypes: (startup.usertypes && Array.isArray(startup.usertypes)
       ? startup.usertypes
       : []) as string[],
-    repository: startup.repository || undefined,
     dsfr_status: startup.dsfr_status || "",
   };
 }

--- a/src/models/startup.ts
+++ b/src/models/startup.ts
@@ -141,6 +141,52 @@ export const eventSchema = z.object({
 
 export type eventSchemaType = z.infer<typeof eventSchema>;
 
+export const STARTUP_URL_TYPES = [
+  "website",
+  "repository",
+  "stats",
+  "budget",
+  "roadmap",
+  "dashlord",
+  "ecodesign",
+  "tech_audit",
+  "impact",
+  "analyse_risques",
+  "tool",
+  "demo",
+  "support",
+  "other",
+] as const;
+
+export type StartupUrlType = (typeof STARTUP_URL_TYPES)[number];
+
+export const startupUrlSchema = z.object({
+  uuid: z.string().optional(),
+  startup_uuid: z.string().optional(),
+  type: z.enum(STARTUP_URL_TYPES),
+  label: z.string().optional().nullable(),
+  url: z.string().min(1, "L'URL est obligatoire"),
+});
+
+export type startupUrlSchemaType = z.infer<typeof startupUrlSchema>;
+
+export const STARTUP_URL_TYPE_LABELS: Record<StartupUrlType, string> = {
+  website: "Site web",
+  repository: "Dépôt de code",
+  stats: "Statistiques d'usage",
+  budget: "Budget",
+  roadmap: "Roadmap / tickets",
+  dashlord: "Rapport DashLord",
+  ecodesign: "Déclaration d'écoconception",
+  tech_audit: "Audit technique",
+  impact: "Matrice d'impact",
+  analyse_risques: "Analyse de risques",
+  tool: "Outil",
+  demo: "Démo",
+  support: "Support",
+  other: "Autre",
+};
+
 export const startupSchema = z.object({
   uuid: z.string(),
   ghid: z.string(),
@@ -178,37 +224,7 @@ export const startupSchema = z.object({
     .email()
     .min(1)
     .describe("Email de contact du produit"),
-  link: z
-    .string()
-    .describe("URL du site web")
-    .url({
-      message:
-        "L'URL fournie doit respecter le format suivant : https://exemple.com",
-    })
-    .or(z.literal(""))
-    .optional()
-    .nullable(),
-  repository: z
-    .string()
-    .describe("URL du repository pour le code source")
-    .optional()
-    .nullable(),
   accessibility_status: z.string().optional().nullable(),
-  dashlord_url: z
-    .string()
-    .describe("URL du rapport DashLord")
-    .optional()
-    .nullable(),
-  stats_url: z
-    .string()
-    .describe("URL de la page de statistiques d'usage")
-    .optional()
-    .nullable(),
-  budget_url: z
-    .string()
-    .describe("URL de la page de budget")
-    .optional()
-    .nullable(),
   mon_service_securise: z
     .boolean()
     .describe("L'équipe a mené une démarche de sécurité sur MonServiceSécurisé")
@@ -219,11 +235,15 @@ export const startupSchema = z.object({
     .describe("Nous avons réalisé une analyse de risque")
     .optional()
     .nullable(),
-  analyse_risques_url: z
-    .string()
-    .describe("URL de l'analyse de risque")
-    .optional()
-    .nullable(),
+  // events: z
+  //     .array(eventSchema.omit({ uuid: true }))
+  //     .optional()
+  //     .nullable(),
+  // phases: z
+  //     .array(phaseSchema)
+  //     .min(1, "Vous devez définir au moins une phase (ex: investigation)")
+  //     .optional()
+  //     .nullable(),
   techno: z.array(z.string()).optional().nullable(),
   mailing_list: z.string().optional().nullable(),
   usertypes: z
@@ -260,26 +280,6 @@ export const startupSchema = z.object({
     .union([z.enum(DSFR_STATUSES), z.string()])
     .describe("Implémentation du design systeme de l'état")
     .optional(),
-  tech_audit_url: z
-    .string()
-    .describe("URL de l'audit technique")
-    .optional()
-    .nullable(),
-  roadmap_url: z
-    .string()
-    .describe("URL de la roadmap ou tickets")
-    .optional()
-    .nullable(),
-  ecodesign_url: z
-    .string()
-    .describe("URL de la déclaration d'écoconception")
-    .optional()
-    .nullable(),
-  impact_url: z
-    .string()
-    .describe("URL de la matrice d'impact")
-    .optional()
-    .nullable(),
 });
 
 export type startupSchemaType = z.infer<typeof startupSchema>;

--- a/src/scripts/github-schemas.ts
+++ b/src/scripts/github-schemas.ts
@@ -38,6 +38,10 @@ export const startup = z.object({
   stats: z.boolean().optional().nullable(),
   stats_url: z.string().optional().nullable(),
   budget_url: z.string().optional().nullable(),
+  roadmap_url: z.string().optional().nullable(),
+  ecodesign_url: z.string().optional().nullable(),
+  tech_audit_url: z.string().optional().nullable(),
+  impact_url: z.string().optional().nullable(),
   analyse_risques: z.boolean().optional().nullable(),
   analyse_risques_url: z.string().optional().nullable(),
   events: z

--- a/src/scripts/import-from-www.ts
+++ b/src/scripts/import-from-www.ts
@@ -103,6 +103,19 @@ const insertData = async (markdownData: MarkdownData) => {
     )
     .returning(["uuid", "ghid"])
     .execute();
+  const URL_TYPE_MAP: { attr: string; type: string }[] = [
+    { attr: "link", type: "website" },
+    { attr: "repository", type: "repository" },
+    { attr: "stats_url", type: "stats" },
+    { attr: "budget_url", type: "budget" },
+    { attr: "roadmap_url", type: "roadmap" },
+    { attr: "dashlord_url", type: "dashlord" },
+    { attr: "ecodesign_url", type: "ecodesign" },
+    { attr: "tech_audit_url", type: "tech_audit" },
+    { attr: "impact_url", type: "impact" },
+    { attr: "analyse_risques_url", type: "analyse_risques" },
+  ];
+
   // insert startups
   const startups = await pAll(
     markdownData.startups.map((startup) => async () => {
@@ -115,17 +128,11 @@ const insertData = async (markdownData: MarkdownData) => {
           name: startup.attributes.title || startup.attributes.ghid,
           contact: startup.attributes.contact,
           incubator_id,
-          link: startup.attributes.link,
-          repository: startup.attributes.repository,
           accessibility_status: startup.attributes.accessibility_status,
           analyse_risques: startup.attributes.analyse_risques,
-          analyse_risques_url: startup.attributes.analyse_risques_url,
-          budget_url: startup.attributes.budget_url,
-          dashlord_url: startup.attributes.dashlord_url,
           mon_service_securise: startup.attributes.mon_service_securise,
           pitch: startup.attributes.mission,
           stats: startup.attributes.stats,
-          stats_url: startup.attributes.stats_url,
           thematiques: JSON.stringify(startup.attributes.thematiques),
           usertypes: JSON.stringify(startup.attributes.usertypes),
           techno: JSON.stringify(startup.attributes.techno),
@@ -135,6 +142,18 @@ const insertData = async (markdownData: MarkdownData) => {
         .returning(["uuid", "ghid"]);
 
       const startupDb = await query.executeTakeFirstOrThrow();
+
+      // Insert startup_urls from YAML attributes
+      const urlsToInsert = URL_TYPE_MAP.flatMap(({ attr, type }) => {
+        const val = (startup.attributes as any)[attr];
+        if (val && typeof val === "string" && val.trim() !== "") {
+          return [{ startup_uuid: startupDb.uuid, type, url: val }];
+        }
+        return [];
+      });
+      if (urlsToInsert.length) {
+        await db.insertInto("startup_urls").values(urlsToInsert).execute();
+      }
 
       // phases
       const phaseNames = startup.attributes.phases?.map((p) => p.name) || [];

--- a/src/scripts/update-local-files.ts
+++ b/src/scripts/update-local-files.ts
@@ -60,21 +60,27 @@ const getChanges = async (markdownData) => {
       ),
     ])
     .execute();
+  const URL_TYPE_TO_YAML: Record<string, string> = {
+    website: "link",
+    repository: "repository",
+    stats: "stats_url",
+    budget: "budget_url",
+    roadmap: "roadmap_url",
+    dashlord: "dashlord_url",
+    ecodesign: "ecodesign_url",
+    tech_audit: "tech_audit_url",
+    impact: "impact_url",
+    analyse_risques: "analyse_risques_url",
+  };
+
   const startupColumns = [
     "startups.ghid",
     "startups.description",
     "startups.accessibility_status",
     "startups.analyse_risques",
-    //"startups.analyse_risques_url",
     "startups.mon_service_securise",
-    "startups.budget_url",
     "startups.contact",
-    "startups.repository",
-    "startups.link",
     "startups.stats",
-    "startups.stats_url",
-    "startups.impact_url",
-    "startups.dashlord_url",
     "startups.name",
     "startups.pitch",
     "startups.thematiques",
@@ -110,6 +116,19 @@ const getChanges = async (markdownData) => {
     ])
     .groupBy([...startupColumns, "startups.uuid", "incubators.ghid"])
     .execute();
+
+  // Fetch all startup_urls grouped by startup_uuid
+  const allStartupUrls = await db
+    .selectFrom("startup_urls")
+    .select(["startup_uuid", "type", "url"])
+    .execute();
+  const urlsByStartup = new Map<string, { type: string; url: string }[]>();
+  for (const row of allStartupUrls) {
+    if (!urlsByStartup.has(row.startup_uuid)) {
+      urlsByStartup.set(row.startup_uuid, []);
+    }
+    urlsByStartup.get(row.startup_uuid)!.push({ type: row.type, url: row.url });
+  }
 
   const userColumns = [
     "users.uuid",
@@ -310,6 +329,15 @@ const getChanges = async (markdownData) => {
       "pitch",
       "uuid",
     ]);
+
+    // Add URL fields from startup_urls table
+    const startupUrlRows = urlsByStartup.get(dbStartup.uuid) || [];
+    for (const { type, url } of startupUrlRows) {
+      const yamlKey = URL_TYPE_TO_YAML[type];
+      if (yamlKey && url) {
+        (dbStartup2 as any)[yamlKey] = url;
+      }
+    }
     if (!ghStartup) {
       // create gh startup
       updates.push({
@@ -339,12 +367,12 @@ const getChanges = async (markdownData) => {
           return;
         }
 
-        const updated = extractValidValues({
+        const updated: any = extractValidValues({
           ...ghStartup2,
           ...dbStartup2,
         });
 
-        updated.link = dbStartup2.link || "";
+        updated.link = (dbStartup2 as any).link || "";
 
         // hack for validation
         updated.phases =


### PR DESCRIPTION
Add a `startup_urls` table to store all startup links

this unlocks a lot of useful metadata:
 - multiple repositories
 - documentations, support urls
 - alternative links...