### PR TITLE
fix(security): enforce auth check in updateMember server action

### DIFF
--- a/src/app/api/member/updateMember.ts
+++ b/src/app/api/member/updateMember.ts
@@ -1,7 +1,9 @@
 "use server";
 
+import { getServerSession } from "next-auth/next";
 import { z } from "zod";
 
+import { canEditMember } from "@/lib/canEditMember";
 import { addEvent } from "@/lib/events";
 import { db } from "@/lib/kysely";
 import {
@@ -17,6 +19,8 @@ import {
 } from "@/models/actions/member";
 import { userInfosToModel } from "@/models/mapper";
 import { EmailStatusCode } from "@/models/member";
+import { authOptions } from "@/utils/authoptions";
+import { AuthorizationError } from "@/utils/error";
 
 export async function updateMember(
   data:
@@ -37,11 +41,21 @@ export async function updateMember(
     | {} = {}, // quick hack to update primary_email,secondary_email and primary_email_status on verify
   created_by_username: string,
 ) {
-  // todo: auth
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.uuid) {
+    throw new AuthorizationError();
+  }
   const { missions, ...memberData } = data;
   const previousInfo = await getUserInfos({ uuid: memberUuid });
   if (!previousInfo) {
     throw new Error("User does not exists");
+  }
+  const isSelfEdit = session.user.uuid === memberUuid;
+  if (
+    !isSelfEdit &&
+    !(await canEditMember({ memberUuid, sessionUser: session.user }))
+  ) {
+    throw new AuthorizationError();
   }
   try {
     await db.transaction().execute(async (trx) => {


### PR DESCRIPTION
## 🛡️ Defense in depth — `updateMember`

### Contexte

`src/app/api/member/updateMember.ts` est exporté avec `"use server"` et porte le marqueur `// todo: auth`. N'importe quel client authentifié peut donc en théorie invoquer cette Server Action depuis n'importe quelle page de l'application, **indépendamment** des contrôles UI ou des routes HTTP qui l'appellent. C'est un trou de sécurité **P0** (escalation horizontale : un membre lambda peut potentiellement modifier la fiche d'un autre membre).

### Correctif

Ajout d'un contrôle d'autorisation **dans la fonction elle-même** :

1. **Session valide obligatoire** → sinon `AuthorizationError` (HTTP 401).
2. **L'utilisateur courant doit être** :
   - soit le membre cible (`session.user.uuid === memberUuid`, *self-edit*),
   - soit autorisé par `canEditMember()` (admin global, équipe d'incubateur du membre cible, ou collègue contractuel·le / fonctionnaire d'une même startup).

Le TODO est supprimé.

### Compatibilité avec les callers existants

| Caller | Auth déjà faite en amont | Pourquoi le nouveau check passe |
|---|---|---|
| `src/app/api/member/[username]/info-update/route.ts` | ✅ admin OU self (par username) | `canEditMember` retourne `true` pour les admins ; le self-edit est couvert directement. |
| `src/app/api/member/actions/verifyNewMember.ts` | ✅ `session.user.id === memberData.username` | `memberUuid` passé est `session.user.uuid` → branche self-edit. |

Aucune modification de la signature de `updateMember`, donc **aucun caller n'est cassé**.

### Validation

- ✅ `npx tsc --noEmit` : aucune nouvelle erreur (les erreurs subsistantes dans `__tests__/` sont pré-existantes et hors scope).
- ✅ Diagnostics IDE : aucun.
- ⏳ Tests `verifyNewMember.test.ts` : stub `updateMember` lui-même → non impacté par la modification interne. La CI les ré-exécutera avec un vrai `.env`.

### Scope

**1 PR = 1 correctif** (conformément à la règle d'équipe). Les deux autres `// todo check that it is authorized` restants (`actions/index.ts:221`, `actions/validateNewMember.ts:97`) feront l'objet de **PR séparées**.

### RGAA / Accessibilité

N/A — modification serveur uniquement, pas de changement UI.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author