### PR TITLE
fix(security): enforce auth check in updateMemberMissions

### DIFF
--- a/src/app/api/member/actions/index.ts
+++ b/src/app/api/member/actions/index.ts
@@ -213,12 +213,15 @@ async function updateMemberMissions(
     throw new NoDataError(`Impossible de trouver les données sur le membre`);
   }
   const previousInfo = memberBaseInfoToModel(dbUser);
+  const isSelfEdit = session.user.uuid === previousInfo.uuid;
   const canEditMember = await _canEditMember({
     memberUuid: previousInfo.uuid,
     sessionUser: session.user,
   });
+  if (!isSelfEdit && !canEditMember) {
+    throw new AuthorizationError();
+  }
 
-  // todo check that it is authorized
   await db.transaction().execute(async (trx) => {
     for (const mission of missions) {
       if (mission.uuid) {


### PR DESCRIPTION
## 🛡️ Defense in depth — `updateMemberMissions`

### Contexte

`src/app/api/member/actions/index.ts` ligne 221 contenait `// todo check that it is authorized`. La Server Action `updateMemberMissions` :

- ✅ vérifiait l'**authentification** (session non vide)
- ❌ **ne vérifiait pas l'autorisation** sur le membre cible

Conséquence : **n'importe quel utilisateur authentifié pouvait modifier les missions de n'importe quel autre membre** (création, modification de startups associées, prolongation de date de fin), tant qu'il ne tentait pas de **raccourcir** une date de fin (seul check existant).

### Correctif

Même logique que [PR #1352](https://github.com/betagouv/espace-membre-next/pull/1352) sur `updateMember` :

- L'utilisateur courant doit être :
  - soit le membre cible (`session.user.uuid === previousInfo.uuid`, *self-edit*),
  - soit autorisé par `canEditMember()` (admin global, équipe d'incubateur, ou collègue contractuel·le / fonctionnaire d'une même startup).
- Sinon : `AuthorizationError` (HTTP 401).

### Règle métier préservée

La restriction existante (lignes 234-243) est inchangée : un membre faisant un **self-edit** a `canEditMember = false`, donc il **ne peut qu'étendre** ses propres missions, jamais les raccourcir. Seuls les admins et membres d'équipe d'incubateur peuvent raccourcir une date de fin.

### Validation

- ✅ `npx tsc --noEmit` : aucune nouvelle erreur.
- ✅ Diagnostics IDE : aucun.
- ✅ Aucune modification de signature → callers existants intacts.

### Scope

**1 PR = 1 correctif**. Reste à traiter : `actions/validateNewMember.ts:97` (PR séparée à venir).

### RGAA / Accessibilité

N/A — Server Action, pas de changement UI.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author