### PR TITLE
fix(security): enforce auth check in updateUserEvent server action

### DIFF
--- a/src/app/api/member/actions/updateUserEvent.spec.ts
+++ b/src/app/api/member/actions/updateUserEvent.spec.ts
@@ -184,7 +184,7 @@ describe("Update user event server action", () => {
     expect(event).to.be.undefined;
   });
 
-  it("should delete event if it exist if value is false when user is not current user", async () => {
+  it("should throw AuthorizationError when a non-admin tries to delete another user's event", async () => {
     const otherUser = await db
       .selectFrom("users")
       .selectAll()
@@ -208,20 +208,27 @@ describe("Update user event server action", () => {
     };
     getServerSessionStub.resolves(mockSession);
 
-    await updateUserEventHandler({
-      value: false,
-      action_on_user_id: otherUser.uuid,
-      field_id: "a-field-id",
-    });
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: false,
+        action_on_user_id: otherUser.uuid,
+        field_id: "a-field-id",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(AuthorizationError);
 
+    // Event must NOT have been deleted.
     const event = await db
       .selectFrom("user_events")
       .where("uuid", "=", userEvent.uuid)
       .executeTakeFirst();
-    expect(event).to.be.undefined;
+    expect(event).to.not.be.undefined;
   });
 
-  it("should create event if value is true when user is not current user", async () => {
+  it("should throw AuthorizationError when a non-admin tries to create an event for another user", async () => {
     const mockSession = {
       user: {
         id: membreActif.username,
@@ -235,17 +242,41 @@ describe("Update user event server action", () => {
       .selectAll()
       .where("username", "=", memberJulienD.username)
       .executeTakeFirstOrThrow();
-    await updateUserEventHandler({
-      value: true,
-      action_on_user_id: otherUser.uuid,
-      field_id: "a-field-id",
-    });
 
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: true,
+        action_on_user_id: otherUser.uuid,
+        field_id: "a-field-id",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+
+    // Event must NOT have been created.
     const event = await db
       .selectFrom("user_events")
       .where("user_id", "=", otherUser.uuid)
       .where("field_id", "=", "a-field-id")
-      .executeTakeFirstOrThrow();
-    event.should.be.exist;
+      .executeTakeFirst();
+    expect(event).to.be.undefined;
+  });
+
+  it("should throw AuthorizationError when there is no session", async () => {
+    getServerSessionStub.resolves(null);
+
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: true,
+        action_on_user_id: user.uuid,
+        field_id: "a-field-id",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(AuthorizationError);
   });
 });

--- a/src/app/api/member/actions/updateUserEvent.ts
+++ b/src/app/api/member/actions/updateUserEvent.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { getServerSession } from "next-auth/next";
 
+import { canEditMember } from "@/lib/canEditMember";
 import { addEvent } from "@/lib/events";
 import { db } from "@/lib/kysely";
 import { getUserInfos } from "@/lib/kysely/queries/users";
@@ -27,10 +28,21 @@ export async function updateUserEvent({
   date?: Date;
 }) {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user.id) {
+  if (!session || !session.user?.uuid) {
     throw new AuthorizationError();
   }
   const user_id = action_on_user_id || session.user.uuid;
+
+  // Defense in depth: only allow editing one's own user events, unless the
+  // session user has edit permissions on the target member (admin, same
+  // incubator team, or shared startup with contractuel/fonctionnaire status).
+  const isSelfEdit = session.user.uuid === user_id;
+  if (
+    !isSelfEdit &&
+    !(await canEditMember({ memberUuid: user_id, sessionUser: session.user }))
+  ) {
+    throw new AuthorizationError();
+  }
 
   const user = await getUserInfos({ uuid: user_id });
   if (!user) {


### PR DESCRIPTION
## 🛡️ Vulnérabilité corrigée

Le Server Action `updateUserEvent` vérifiait uniquement la présence d'une session, sans contrôler que l'utilisateur connecté était habilité à modifier les `user_events` du `action_on_user_id` reçu en paramètre.

**Conséquence** : tout utilisateur authentifié pouvait créer ou supprimer des items de checklist (onboarding/offboarding) pour n'importe quel autre membre de la communauté.

Les tests d'intégration existants vérifiaient explicitement ce comportement vulnérable (« should create event / delete event when user is not current user »), ce qui confirme que la vérification avait été oubliée plutôt qu'intentionnellement omise.

## 🔒 Correctif (defense in depth)

```typescript
const isSelfEdit = session.user.uuid === user_id;
if (
  !isSelfEdit &&
  !(await canEditMember({ memberUuid: user_id, sessionUser: session.user }))
) {
  throw new AuthorizationError();
}
```

La règle de permission **reflete exactement** celle déjà appliquée côté UI dans `MemberPage` (`readOnly={!canEditMember}` sur `<ChecklistTabPanel />`) :
- ✅ self-edit (`session.user.uuid === target user_id`) : toujours autorisé
- ✅ admin
- ✅ même équipe d'incubateur que la cible
- ✅ même startup que la cible **et** statut légal « contractuel » ou « fonctionnaire »
- ❌ sinon : `AuthorizationError`

## 🧪 Tests

Les 2 tests qui validaient le comportement vulnérable sont réécrits :

| Test | Avant | Après |
|---|---|---|
| `should ... when user is not current user` (delete) | passait → attendait que la suppression réussisse | attend `AuthorizationError` + vérifie que l'événement n'a **pas** été supprimé |
| `should ... when user is not current user` (create) | passait → attendait que la création réussisse | attend `AuthorizationError` + vérifie que l'événement n'a **pas** été créé |

Un nouveau test couvre le cas « session manquante » :
```typescript
it("should throw AuthorizationError when there is no session", ...)
```

Les 5 tests existants légitimes (self-edit, admin) restent inchangés.

## 📁 Diff

| Fichier | + | - |
|---|---|---|
| `updateUserEvent.ts` | 14 | 2 |
| `updateUserEvent.spec.ts` | 47 | 14 |

## 🔗 Chaîne de PRs P0 sécurité

- #1352 `updateMember` (mergeable)
- #1353 `updateMemberMissions` (mergeable)
- #1354 `validateNewMember` (mergeable)
- **#XXXX `updateUserEvent` (cette PR)**
- à venir : `startups/files/*` (PRs séparées)

Refs : `AUDIT.md`, RFC-001.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author