### PR TITLE
fix(security): enforce canEditStartup in uploadStartupFile

### DIFF
--- a/src/app/api/startups/files/upload.spec.ts
+++ b/src/app/api/startups/files/upload.spec.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+
+import { uploadStartupFile } from "./upload";
+import { AuthorizationError } from "@/utils/error";
+
+describe("uploadStartupFile server action — authorization", () => {
+  let getServerSessionStub: sinon.SinonStub;
+  let canEditStartupStub: sinon.SinonStub;
+  let executeTakeFirstOrThrowStub: sinon.SinonStub;
+  let revalidatePathStub: sinon.SinonStub;
+  let handler: typeof uploadStartupFile;
+
+  const baseParams = {
+    title: "title",
+    type: "convention" as any,
+    uuid: "startup-uuid",
+    content: "data:application/pdf;base64,Zm9v",
+    comments: "",
+    filename: "file.pdf",
+    size: 100,
+    data: {},
+  };
+
+  beforeEach(() => {
+    sinon.restore();
+
+    getServerSessionStub = sinon.stub();
+    canEditStartupStub = sinon.stub();
+    revalidatePathStub = sinon.stub();
+    executeTakeFirstOrThrowStub = sinon.stub().resolves({ uuid: "file-uuid" });
+
+    // Minimal kysely query builder stub: db.insertInto().values().returning().executeTakeFirstOrThrow()
+    const dbStub = {
+      insertInto: () => ({
+        values: () => ({
+          returning: () => ({
+            executeTakeFirstOrThrow: executeTakeFirstOrThrowStub,
+          }),
+        }),
+      }),
+    };
+
+    handler = proxyquire("./upload", {
+      "next-auth": { getServerSession: getServerSessionStub },
+      "next/cache": { revalidatePath: revalidatePathStub },
+      "@/lib/canEditStartup": { canEditStartup: canEditStartupStub },
+      "@/lib/kysely": { db: dbStub },
+    }).uploadStartupFile as typeof uploadStartupFile;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("throws AuthorizationError when there is no session", async () => {
+    getServerSessionStub.resolves(null);
+
+    let thrown: unknown;
+    try {
+      await handler(baseParams);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+    expect(canEditStartupStub.notCalled).to.be.true;
+    expect(executeTakeFirstOrThrowStub.notCalled).to.be.true;
+  });
+
+  it("throws AuthorizationError when the user cannot edit the target startup", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    canEditStartupStub.resolves(false);
+
+    let thrown: unknown;
+    try {
+      await handler(baseParams);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+    expect(
+      canEditStartupStub.calledOnceWithExactly(
+        sinon.match.object,
+        baseParams.uuid,
+      ),
+    ).to.be.true;
+    expect(executeTakeFirstOrThrowStub.notCalled).to.be.true;
+  });
+
+  it("inserts the file when canEditStartup returns true", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    canEditStartupStub.resolves(true);
+
+    const result = await handler(baseParams);
+
+    expect(canEditStartupStub.calledOnce).to.be.true;
+    expect(executeTakeFirstOrThrowStub.calledOnce).to.be.true;
+    expect(revalidatePathStub.calledOnceWithExactly("/startups")).to.be.true;
+    expect(result).to.deep.equal({ uuid: "file-uuid" });
+  });
+});

--- a/src/app/api/startups/files/upload.ts
+++ b/src/app/api/startups/files/upload.ts
@@ -2,9 +2,11 @@
 import { revalidatePath } from "next/cache";
 import { getServerSession } from "next-auth";
 
+import { canEditStartup } from "@/lib/canEditStartup";
 import { db } from "@/lib/kysely";
 import { DocSchemaType } from "@/models/startupFiles";
 import { authOptions } from "@/utils/authoptions";
+import { AuthorizationError } from "@/utils/error";
 
 const commonFileFields = [
   "startups_files.filename",
@@ -39,11 +41,15 @@ export async function uploadStartupFile(
 ) {
   const session = await getServerSession(authOptions);
   if (!session || !session.user.id) {
-    throw new Error(`You don't have the right to access this function`);
+    throw new AuthorizationError();
+  }
+  // Defense in depth: only allow uploading files to a startup the user can
+  // edit (admin, member of the incubator team, or active startup agent).
+  if (!(await canEditStartup(session, uuid))) {
+    throw new AuthorizationError();
   }
   const base64 = Buffer.from(content);
 
-  // todo: ensure user can upload files here
   const inserted = await db
     .insertInto("startups_files")
     .values({


### PR DESCRIPTION
## 🛡️ Vulnérabilité corrigée

Le Server Action `uploadStartupFile` vérifiait uniquement la présence d'une session : tout utilisateur authentifié pouvait uploader un fichier (contrats, conventions, documents internes...) attaché à **n'importe quelle startup**, y compris celles auxquelles il n'appartenait pas.

Le code contenait déjà le marqueur `// todo: ensure user can upload files here`.

## 🔒 Correctif (defense in depth)

```typescript
if (!(await canEditStartup(session, uuid))) {
  throw new AuthorizationError();
}
```

La règle de permission utilise le helper déjà existant `canEditStartup` :
- ✅ admin
- ✅ membre de l'équipe d'incubateur de la startup cible
- ✅ agent actif de la startup cible (membre via `missions`)
- ❌ sinon : `AuthorizationError`

Le `Error` générique pour la session manquante est aussi remplacé par `AuthorizationError`, par cohérence avec le reste de l'API.

## 🧪 Tests

Nouveau fichier `upload.spec.ts` (3 tests unitaires via proxyquire, **sans DB requise**) :

| Test | Vérifie |
|---|---|
| `throws AuthorizationError when there is no session` | session manquante → erreur, `canEditStartup` non appelé, pas d'insert |
| `throws AuthorizationError when the user cannot edit the target startup` | session présente + `canEditStartup` → false → erreur, pas d'insert |
| `inserts the file when canEditStartup returns true` | session présente + `canEditStartup` → true → insert exécuté, `revalidatePath` appelé |

## 📁 Diff

| Fichier | + | - |
|---|---|---|
| `upload.ts` | 8 | 2 |
| `upload.spec.ts` (nouveau) | 108 | 0 |

## 🔗 Chaîne de PRs P0 sécurité

- #1352 `updateMember`
- #1353 `updateMemberMissions`
- #1354 `validateNewMember`
- #1357 `updateUserEvent`
- **#XXXX `uploadStartupFile` (cette PR)**
- à venir : `deleteFile`, `download/[id]/route.ts`

Refs : `AUDIT.md`, RFC-001.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author