### PR TITLE
fix(security): enforce canEditStartup in deleteFile (startup files)

### DIFF
--- a/src/app/api/startups/files/delete.spec.ts
+++ b/src/app/api/startups/files/delete.spec.ts
@@ -1,0 +1,127 @@
+import { expect } from "chai";
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+
+import { deleteFile } from "./delete";
+import { AuthorizationError, BusinessError } from "@/utils/error";
+
+describe("deleteFile server action — authorization", () => {
+  let getServerSessionStub: sinon.SinonStub;
+  let canEditStartupStub: sinon.SinonStub;
+  let selectExecuteTakeFirstStub: sinon.SinonStub;
+  let updateExecuteTakeFirstOrThrowStub: sinon.SinonStub;
+  let handler: typeof deleteFile;
+
+  const fileUuid = "file-uuid";
+  const startupUuid = "startup-uuid";
+
+  beforeEach(() => {
+    sinon.restore();
+
+    getServerSessionStub = sinon.stub();
+    canEditStartupStub = sinon.stub();
+    selectExecuteTakeFirstStub = sinon.stub();
+    updateExecuteTakeFirstOrThrowStub = sinon.stub().resolves({});
+
+    // Minimal kysely query builder stub:
+    // db.selectFrom().select().where().where().executeTakeFirst() and
+    // db.updateTable().set().where().executeTakeFirstOrThrow()
+    const dbStub = {
+      selectFrom: () => ({
+        select: () => ({
+          where: () => ({
+            where: () => ({ executeTakeFirst: selectExecuteTakeFirstStub }),
+          }),
+        }),
+      }),
+      updateTable: () => ({
+        set: () => ({
+          where: () => ({
+            executeTakeFirstOrThrow: updateExecuteTakeFirstOrThrowStub,
+          }),
+        }),
+      }),
+    };
+
+    handler = proxyquire("./delete", {
+      "next-auth": { getServerSession: getServerSessionStub },
+      "@/lib/canEditStartup": { canEditStartup: canEditStartupStub },
+      "@/lib/kysely": { db: dbStub },
+    }).deleteFile as typeof deleteFile;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("throws AuthorizationError when there is no session", async () => {
+    getServerSessionStub.resolves(null);
+
+    let thrown: unknown;
+    try {
+      await handler({ uuid: fileUuid });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+    expect(selectExecuteTakeFirstStub.notCalled).to.be.true;
+    expect(updateExecuteTakeFirstOrThrowStub.notCalled).to.be.true;
+  });
+
+  it("throws BusinessError when the file does not exist", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    selectExecuteTakeFirstStub.resolves(undefined);
+
+    let thrown: unknown;
+    try {
+      await handler({ uuid: fileUuid });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).to.be.instanceOf(BusinessError);
+    expect(canEditStartupStub.notCalled).to.be.true;
+    expect(updateExecuteTakeFirstOrThrowStub.notCalled).to.be.true;
+  });
+
+  it("throws AuthorizationError when the user cannot edit the file's startup", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    selectExecuteTakeFirstStub.resolves({ startup_id: startupUuid });
+    canEditStartupStub.resolves(false);
+
+    let thrown: unknown;
+    try {
+      await handler({ uuid: fileUuid });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+    expect(
+      canEditStartupStub.calledOnceWithExactly(
+        sinon.match.object,
+        startupUuid,
+      ),
+    ).to.be.true;
+    expect(updateExecuteTakeFirstOrThrowStub.notCalled).to.be.true;
+  });
+
+  it("soft-deletes the file when canEditStartup returns true", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    selectExecuteTakeFirstStub.resolves({ startup_id: startupUuid });
+    canEditStartupStub.resolves(true);
+
+    const result = await handler({ uuid: fileUuid });
+
+    expect(canEditStartupStub.calledOnce).to.be.true;
+    expect(updateExecuteTakeFirstOrThrowStub.calledOnce).to.be.true;
+    expect(result).to.equal(true);
+  });
+});

--- a/src/app/api/startups/files/delete.ts
+++ b/src/app/api/startups/files/delete.ts
@@ -2,14 +2,32 @@
 
 import { getServerSession } from "next-auth";
 
+import { canEditStartup } from "@/lib/canEditStartup";
 import { db } from "@/lib/kysely";
 import { authOptions } from "@/utils/authoptions";
+import { AuthorizationError, BusinessError } from "@/utils/error";
 
 export async function deleteFile({ uuid }: { uuid: string }) {
   const session = await getServerSession(authOptions);
   if (!session || !session.user.id) {
-    throw new Error(`You don't have the right to access this function`);
+    throw new AuthorizationError();
   }
+
+  // Defense in depth: fetch the file's parent startup and verify the session
+  // user has edit rights on it before allowing the (soft-)delete.
+  const file = await db
+    .selectFrom("startups_files")
+    .select(["startup_id"])
+    .where("uuid", "=", uuid)
+    .where("deleted_at", "is", null)
+    .executeTakeFirst();
+  if (!file) {
+    throw new BusinessError("fileNotFound", `File ${uuid} not found`);
+  }
+  if (!(await canEditStartup(session, file.startup_id))) {
+    throw new AuthorizationError();
+  }
+
   await db
     .updateTable("startups_files")
     .set({ deleted_by: session.user.uuid, deleted_at: new Date() })


### PR DESCRIPTION
## 🛡️ Vulnérabilité corrigée

Le Server Action `deleteFile` vérifiait uniquement la présence d'une session : tout utilisateur authentifié pouvait supprimer (soft-delete) **n'importe quel fichier de n'importe quelle startup** en fournissant son UUID (potentiellement énuméré via la page « Documents partagés »).

Le code contenait déjà un comportement no-op silencieux pour les UUID inexistants, qui est aussi corrigé.

## 🔒 Correctif (defense in depth)

```typescript
const file = await db
  .selectFrom("startups_files")
  .select(["startup_id"])
  .where("uuid", "=", uuid)
  .where("deleted_at", "is", null)
  .executeTakeFirst();
if (!file) {
  throw new BusinessError("fileNotFound", `File ${uuid} not found`);
}
if (!(await canEditStartup(session, file.startup_id))) {
  throw new AuthorizationError();
}
```

Règle de permission via `canEditStartup` :
- ✅ admin
- ✅ membre de l'équipe d'incubateur de la startup
- ✅ agent actif de la startup
- ❌ sinon : `AuthorizationError`

Les erreurs génériques sont remplacées par `AuthorizationError` / `BusinessError` pour cohérence.

## 🧪 Tests

Nouveau fichier `delete.spec.ts` (4 tests unitaires via proxyquire, **sans DB requise**) :

| Test | Vérifie |
|---|---|
| `throws AuthorizationError when there is no session` | session manquante → erreur, aucun accès DB |
| `throws BusinessError when the file does not exist` | UUID inconnu → erreur 404, `canEditStartup` non appelé |
| `throws AuthorizationError when the user cannot edit the file's startup` | `canEditStartup` → false → erreur, pas d'update |
| `soft-deletes the file when canEditStartup returns true` | succès → update exécuté |

## 📁 Diff

| Fichier | + | - |
|---|---|---|
| `delete.ts` | 19 | 1 |
| `delete.spec.ts` (nouveau) | 127 | 0 |

## 🔗 Chaîne de PRs P0 sécurité

- #1352 `updateMember`
- #1353 `updateMemberMissions`
- #1354 `validateNewMember`
- #1357 `updateUserEvent`
- #1358 `uploadStartupFile`
- **#XXXX `deleteFile` (cette PR)**
- à venir : `download/[id]/route.ts`

Refs : `AUDIT.md`, RFC-001.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author