### PR TITLE
fix(security): enforce canEditStartup in startup file download route

### DIFF
--- a/src/app/api/startups/files/download/[id]/route.spec.ts
+++ b/src/app/api/startups/files/download/[id]/route.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from "chai";
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+
+describe("startups/files/download/[id] route — authorization", () => {
+  let getServerSessionStub: sinon.SinonStub;
+  let canEditStartupStub: sinon.SinonStub;
+  let executeTakeFirstOrThrowStub: sinon.SinonStub;
+  let GET: (req: any, ctx: { params: { id: string } }) => Promise<Response>;
+
+  const fileUuid = "file-uuid";
+  const startupUuid = "startup-uuid";
+
+  beforeEach(() => {
+    sinon.restore();
+
+    getServerSessionStub = sinon.stub();
+    canEditStartupStub = sinon.stub();
+    executeTakeFirstOrThrowStub = sinon.stub();
+
+    // Minimal kysely query builder stub:
+    // db.selectFrom().select().where().where().executeTakeFirstOrThrow()
+    const dbStub = {
+      selectFrom: () => ({
+        select: () => ({
+          where: () => ({
+            where: () => ({
+              executeTakeFirstOrThrow: executeTakeFirstOrThrowStub,
+            }),
+          }),
+        }),
+      }),
+    };
+
+    GET = proxyquire("./route", {
+      "next-auth": { getServerSession: getServerSessionStub },
+      "@/lib/canEditStartup": { canEditStartup: canEditStartupStub },
+      "@/lib/kysely": { db: dbStub },
+    }).GET;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("returns 403 when there is no session", async () => {
+    getServerSessionStub.resolves(null);
+
+    const res = await GET({} as any, { params: { id: fileUuid } });
+
+    expect(res.status).to.equal(403);
+    expect(executeTakeFirstOrThrowStub.notCalled).to.be.true;
+    expect(canEditStartupStub.notCalled).to.be.true;
+  });
+
+  it("returns 403 when the user cannot edit the file's startup", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    executeTakeFirstOrThrowStub.resolves({
+      filename: "f.pdf",
+      base64: Buffer.from("data:application/pdf;base64,Zm9v"),
+      startup_id: startupUuid,
+    });
+    canEditStartupStub.resolves(false);
+
+    const res = await GET({} as any, { params: { id: fileUuid } });
+
+    expect(res.status).to.equal(403);
+    expect(
+      canEditStartupStub.calledOnceWithExactly(
+        sinon.match.object,
+        startupUuid,
+      ),
+    ).to.be.true;
+  });
+
+  it("returns the file content when canEditStartup returns true", async () => {
+    getServerSessionStub.resolves({
+      user: { id: "u1", uuid: "session-uuid", isAdmin: false },
+    });
+    executeTakeFirstOrThrowStub.resolves({
+      filename: "f.pdf",
+      base64: Buffer.from("data:application/pdf;base64,Zm9v"),
+      startup_id: startupUuid,
+    });
+    canEditStartupStub.resolves(true);
+
+    const res = await GET({} as any, { params: { id: fileUuid } });
+
+    expect(res.status).to.equal(200);
+    expect(canEditStartupStub.calledOnce).to.be.true;
+    const body = await res.arrayBuffer();
+    // "Zm9v" base64-decoded == "foo"
+    expect(Buffer.from(body).toString("utf8")).to.equal("foo");
+  });
+});

--- a/src/app/api/startups/files/download/[id]/route.ts
+++ b/src/app/api/startups/files/download/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 
+import { canEditStartup } from "@/lib/canEditStartup";
 import { db } from "@/lib/kysely";
 import { authOptions } from "@/utils/authoptions";
 import {
@@ -23,13 +24,20 @@ async function getFileHandler(
       `Identifiant du fichier non fourni`,
     );
   }
-  // todo: ensure user can download files here
   const file = await db
     .selectFrom("startups_files")
-    .select(["filename", "base64"])
+    .select(["filename", "base64", "startup_id"])
     .where("uuid", "=", id)
     .where("deleted_at", "is", null)
     .executeTakeFirstOrThrow();
+
+  // Defense in depth: only allow downloading files attached to a startup the
+  // session user can edit (admin, member of the incubator team, or active
+  // startup agent). Startup files may contain sensitive documents
+  // (conventions, contracts, personal data).
+  if (!(await canEditStartup(session, file.startup_id))) {
+    throw new AuthorizationError();
+  }
 
   if (file.base64) {
     const decoded = file.base64.toString().split(",").slice(1).join(""); // remove base64 header


### PR DESCRIPTION
## 🛡️ Vulnérabilité corrigée

La route `GET /api/startups/files/download/[id]` vérifiait uniquement la présence d'une session : tout utilisateur authentifié pouvait télécharger **n'importe quel fichier de n'importe quelle startup** (conventions, contrats, documents internes, données personnelles) en fournissant son UUID.

Le code contenait déjà le marqueur `// todo: ensure user can download files here`.

## 🔒 Correctif (defense in depth)

```typescript
const file = await db
  .selectFrom("startups_files")
  .select(["filename", "base64", "startup_id"])
  .where("uuid", "=", id)
  .where("deleted_at", "is", null)
  .executeTakeFirstOrThrow();

if (!(await canEditStartup(session, file.startup_id))) {
  throw new AuthorizationError();
}
```

Règle de permission via `canEditStartup` :
- ✅ admin
- ✅ membre de l'équipe d'incubateur de la startup
- ✅ agent actif de la startup
- ❌ sinon : `AuthorizationError` → HTTP 403

## 🧪 Tests

Nouveau fichier `route.spec.ts` (3 tests unitaires via proxyquire, **sans DB requise**) :

| Test | Vérifie |
|---|---|
| `returns 403 when there is no session` | session manquante → HTTP 403, aucun accès DB, `canEditStartup` non appelé |
| `returns 403 when the user cannot edit the file's startup` | `canEditStartup` → false → HTTP 403, pas de contenu retourné |
| `returns the file content when canEditStartup returns true` | succès → HTTP 200, bytes du fichier retournés |

## 📁 Diff

| Fichier | + | - |
|---|---|---|
| `download/[id]/route.ts` | 10 | 2 |
| `download/[id]/route.spec.ts` (nouveau) | 97 | 0 |

## 🔗 Chaîne de PRs P0 sécurité (fichiers startups)

- #1358 `uploadStartupFile`
- #1359 `deleteFile`
- **#XXXX `download/[id]/route.ts` (cette PR)** ← clôt la trilogie startups/files

Refs : `AUDIT.md`, RFC-001.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author