### PR TITLE
fix(a11y): add lang attribute on top-level <html> tags (RGAA 8.3)

### DIFF
--- a/__tests__/a11y-html-has-lang.spec.ts
+++ b/__tests__/a11y-html-has-lang.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+import path from "path";
+
+import { ESLint } from "eslint";
+
+/**
+ * Anti-regression guard for RGAA criterion 8.3 (page language declared).
+ *
+ * Verifies, via the project's flat ESLint config, that the two files
+ * containing top-level <html> tags emit zero `jsx-a11y/html-has-lang`
+ * warnings.
+ *
+ * If a future change removes the `lang` attribute (or the eslint-disable
+ * comment that documents the DSFR spread case in layout.tsx), this test
+ * fails immediately.
+ */
+describe("a11y — jsx-a11y/html-has-lang", () => {
+  const repoRoot = path.resolve(__dirname, "..");
+  const targets = [
+    path.join(repoRoot, "src", "app", "global-error.tsx"),
+    path.join(repoRoot, "src", "app", "layout.tsx"),
+  ];
+
+  it("emits 0 html-has-lang warnings on top-level <html> files", async () => {
+    const eslint = new ESLint({ cwd: repoRoot });
+    const results = await eslint.lintFiles(targets);
+
+    const offending = results.flatMap((r) =>
+      r.messages
+        .filter((m) => m.ruleId === "jsx-a11y/html-has-lang")
+        .map(
+          (m) =>
+            `${path.relative(repoRoot, r.filePath)}:${m.line} ${m.message}`,
+        ),
+    );
+
+    expect(offending, offending.join("\n")).to.have.lengthOf(0);
+  }).timeout(30000);
+});

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -15,7 +15,7 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html>
+    <html lang="fr">
       <body>
         {/* This is the default Next.js error component but it doesn't allow omitting the statusCode property yet. */}
         <NextError statusCode={undefined as any} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -109,6 +109,7 @@ function RootLayout(props: PropsWithChildren<RootLayoutProps>) {
   }
 
   return (
+    // eslint-disable-next-line jsx-a11y/html-has-lang -- lang is set via the DSFR getHtmlAttributes spread; ESLint cannot detect attributes from a spread.
     <html {...getHtmlAttributes({ lang: "fr" })}>
       <MainStructure {...props} />
     </html>


### PR DESCRIPTION
## ♿ Problème d'accessibilité

Deux warnings `jsx-a11y/html-has-lang` repérés sur des balises `<html>` sans attribut `lang` après l'activation du preset complet (PR #1355).

**RGAA critère 8.3** : *La langue par défaut de chaque page web est-elle indiquée ?*

Sans `lang` :
- les lecteurs d'écran (NVDA, JAWS, VoiceOver) lisent le contenu avec la mauvaise prononciation
- les outils de traduction automatique partent sur de fausses bases

## 🔧 Correctifs

| Fichier | Avant | Après |
|---|---|---|
| `src/app/global-error.tsx` | `<html>` | `<html lang="fr">` |
| `src/app/layout.tsx` | `<html {...getHtmlAttributes({ lang: "fr" })}>` | id. + `eslint-disable-next-line` documenté |

Dans `layout.tsx`, l'attribut `lang` est déjà injecté via le spread DSFR `getHtmlAttributes` mais ESLint ne sait pas résoudre les attributs d'un spread. Comme dupliquer l'attribut n'est pas élégant, je documente le faux positif avec une directive `eslint-disable-next-line` ciblant uniquement la règle `jsx-a11y/html-has-lang`.

## 🧪 Test (anti-régression)

Nouveau fichier `__tests__/a11y-html-has-lang.spec.ts` qui utilise l'API `ESLint` pour valider qu'aucun warning `jsx-a11y/html-has-lang` n'est émis sur ces deux fichiers.

Vérifié :
- ❌ **avant** le fix : test échoue avec exactement les 2 warnings ciblés
- ✅ **après** le fix : test passe (3s)

## 📁 Diff

```
 __tests__/a11y-html-has-lang.spec.ts | 39 ++++++++++++++++++++++++++++++++++++
 src/app/global-error.tsx             |  2 +-
 src/app/layout.tsx                   |  1 +
 3 files changed, 41 insertions(+), 1 deletion(-)
```

## 📊 Impact baseline RGAA

- Avant : **29 warnings** `jsx-a11y` dont 2 `html-has-lang`
- Après : **27 warnings** `jsx-a11y`

Prochains chantiers (1 PR par règle) : `click-events-have-key-events` (10), `no-static-element-interactions` (6), `label-has-associated-control` (5)…

Refs : `AUDIT.md`, RFC-001, PR baseline #1355.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author