### PR TITLE
chore(security): guard import-from-www and wrap in transaction (EXP-1)

### DIFF
--- a/src/scripts/import-from-www.spec.ts
+++ b/src/scripts/import-from-www.spec.ts
@@ -1,0 +1,81 @@
+import { expect } from "chai";
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+
+// Stub heavy/side-effecting imports so the spec can load the module
+// without requiring DATABASE_URL / SESSION_SECRET / a real DB connection.
+const { assertDestructiveImportAllowed } = proxyquire.noCallThru()(
+  "./import-from-www",
+  {
+    "@/server/config": { default: { domain: "test.local" } },
+    "@lib/kysely": { db: {} },
+  },
+) as typeof import("./import-from-www");
+
+describe("import-from-www destructive guard", () => {
+  let warnStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    warnStub = sinon.stub(console, "warn");
+  });
+
+  afterEach(() => {
+    warnStub.restore();
+  });
+
+  it("throws when NODE_ENV=production and ALLOW_DESTRUCTIVE_IMPORT is not set", () => {
+    expect(() =>
+      assertDestructiveImportAllowed({ NODE_ENV: "production" }),
+    ).to.throw(/Refused to run import-from-www in production/);
+    expect(warnStub.called).to.equal(false);
+  });
+
+  it("throws when NODE_ENV=production and ALLOW_DESTRUCTIVE_IMPORT is not exactly 'true'", () => {
+    expect(() =>
+      assertDestructiveImportAllowed({
+        NODE_ENV: "production",
+        ALLOW_DESTRUCTIVE_IMPORT: "1",
+      }),
+    ).to.throw(/Refused to run import-from-www in production/);
+    expect(() =>
+      assertDestructiveImportAllowed({
+        NODE_ENV: "production",
+        ALLOW_DESTRUCTIVE_IMPORT: "yes",
+      }),
+    ).to.throw(/Refused to run import-from-www in production/);
+  });
+
+  it("does not throw when NODE_ENV=production and ALLOW_DESTRUCTIVE_IMPORT='true' (with warning)", () => {
+    expect(() =>
+      assertDestructiveImportAllowed({
+        NODE_ENV: "production",
+        ALLOW_DESTRUCTIVE_IMPORT: "true",
+      }),
+    ).to.not.throw();
+    expect(warnStub.calledOnce).to.equal(true);
+    expect(warnStub.firstCall.args[0]).to.match(
+      /ALLOW_DESTRUCTIVE_IMPORT=true detected/,
+    );
+  });
+
+  it("does not throw in non-production environments", () => {
+    expect(() =>
+      assertDestructiveImportAllowed({ NODE_ENV: "development" }),
+    ).to.not.throw();
+    expect(() =>
+      assertDestructiveImportAllowed({ NODE_ENV: "test" }),
+    ).to.not.throw();
+    expect(() => assertDestructiveImportAllowed({})).to.not.throw();
+    expect(warnStub.called).to.equal(false);
+  });
+
+  it("warns in non-production envs as well when ALLOW_DESTRUCTIVE_IMPORT=true", () => {
+    expect(() =>
+      assertDestructiveImportAllowed({
+        NODE_ENV: "development",
+        ALLOW_DESTRUCTIVE_IMPORT: "true",
+      }),
+    ).to.not.throw();
+    expect(warnStub.calledOnce).to.equal(true);
+  });
+});

--- a/src/scripts/import-from-www.ts
+++ b/src/scripts/import-from-www.ts
@@ -1,4 +1,5 @@
 import fm from "front-matter";
+import { Transaction } from "kysely";
 import pAll from "p-all";
 import unzipper, { Entry } from "unzipper";
 import { ZodSchema, z } from "zod";
@@ -11,27 +12,64 @@ import {
   team,
 } from "./github-schemas";
 import { importFromZip, MarkdownData } from "./utils";
+import { DB } from "@/@types/db";
 import config from "@/server/config";
 import { db } from "@lib/kysely";
 
 const { Readable } = require("stream");
 
-const insertData = async (markdownData: MarkdownData) => {
+/**
+ * Refuse to run the destructive import in production unless the operator
+ * explicitly opts in via the ALLOW_DESTRUCTIVE_IMPORT env var.
+ *
+ * `import-from-www` truncates and re-inserts the bulk of the database
+ * (incubators, teams, startups, missions, phases, events, organisations).
+ * Running it on the production database would wipe out edits made by
+ * members between two runs and break the data flow.
+ *
+ * Export so the guard can be unit-tested in isolation.
+ */
+export const assertDestructiveImportAllowed = (
+  env: NodeJS.ProcessEnv = process.env,
+) => {
+  const isProduction = env.NODE_ENV === "production";
+  const isExplicitlyAllowed = env.ALLOW_DESTRUCTIVE_IMPORT === "true";
+
+  if (isProduction && !isExplicitlyAllowed) {
+    throw new Error(
+      "Refused to run import-from-www in production: this script truncates " +
+        "incubators/teams/startups/missions/phases/events/organisations. " +
+        "Set ALLOW_DESTRUCTIVE_IMPORT=true to override (use only on dev/staging).",
+    );
+  }
+
+  if (isExplicitlyAllowed) {
+    console.warn(
+      "ALLOW_DESTRUCTIVE_IMPORT=true detected — destructive import is allowed " +
+        "in the current environment. This will TRUNCATE database tables.",
+    );
+  }
+};
+
+export const insertData = async (
+  markdownData: MarkdownData,
+  trx: Transaction<DB>,
+) => {
   // truncate tables
-  // do not drop users -- await db.deleteFrom("users").execute();
-  await db.deleteFrom("missions_startups").execute();
-  await db.deleteFrom("missions").execute();
-  await db.deleteFrom("phases").execute();
-  await db.deleteFrom("startups_organizations").execute();
-  await db.deleteFrom("startup_events").execute();
-  await db.deleteFrom("events").execute();
-  await db.deleteFrom("startups").execute();
-  await db.deleteFrom("incubators").execute();
-  await db.deleteFrom("organizations").execute();
-  await db.deleteFrom("teams").execute();
+  // do not drop users -- await trx.deleteFrom("users").execute();
+  await trx.deleteFrom("missions_startups").execute();
+  await trx.deleteFrom("missions").execute();
+  await trx.deleteFrom("phases").execute();
+  await trx.deleteFrom("startups_organizations").execute();
+  await trx.deleteFrom("startup_events").execute();
+  await trx.deleteFrom("events").execute();
+  await trx.deleteFrom("startups").execute();
+  await trx.deleteFrom("incubators").execute();
+  await trx.deleteFrom("organizations").execute();
+  await trx.deleteFrom("teams").execute();
 
   // insert organisations
-  const organisations = await db
+  const organisations = await trx
     .insertInto("organizations")
     .values(
       markdownData.organisations.map((orga) => ({
@@ -46,7 +84,7 @@ const insertData = async (markdownData: MarkdownData) => {
     .execute();
 
   // insert incubators
-  const incubators = await db
+  const incubators = await trx
     .insertInto("incubators")
     .values(({ selectFrom }) =>
       markdownData.incubators
@@ -84,7 +122,7 @@ const insertData = async (markdownData: MarkdownData) => {
     .execute();
 
   // insert teams
-  const teams = await db
+  const teams = await trx
     .insertInto("teams")
     .values(({ selectFrom }) =>
       markdownData.teams.map((team) => ({
@@ -109,7 +147,7 @@ const insertData = async (markdownData: MarkdownData) => {
       const incubator_id = incubators.find(
         (o) => o.ghid === startup.attributes.incubator,
       )?.uuid;
-      const query = db
+      const query = trx
         .insertInto("startups")
         .values({
           name: startup.attributes.title || startup.attributes.ghid,
@@ -156,7 +194,7 @@ const insertData = async (markdownData: MarkdownData) => {
           }
 
           return (
-            db
+            trx
               .insertInto("phases")
               .values({
                 //@ts-ignore todo
@@ -176,7 +214,7 @@ const insertData = async (markdownData: MarkdownData) => {
       );
 
       if (startup.attributes.sponsors && startup.attributes.sponsors.length) {
-        await db
+        await trx
           .insertInto("startups_organizations")
           .values(
             ({ selectFrom }) =>
@@ -192,7 +230,7 @@ const insertData = async (markdownData: MarkdownData) => {
 
       // events
       if (startup.attributes.events && startup.attributes.events.length) {
-        await db
+        await trx
           .insertInto("startup_events")
           .values(
             startup.attributes.events?.map((event) => ({
@@ -206,7 +244,7 @@ const insertData = async (markdownData: MarkdownData) => {
       }
 
       if (startup.attributes.fast) {
-        await db
+        await trx
           .insertInto("startup_events")
           .values({
             name: "fast",
@@ -225,7 +263,7 @@ const insertData = async (markdownData: MarkdownData) => {
   // insert users
   const authors = await pAll(
     markdownData.authors.map((author) => async () => {
-      const query = db
+      const query = trx
         .insertInto("users")
         .values({
           fullname: author.attributes.fullname,
@@ -267,7 +305,7 @@ const insertData = async (markdownData: MarkdownData) => {
             end = undefined;
           }
           const mission_id = (
-            await db
+            await trx
               .insertInto("missions")
               .values({
                 start: mission.start || new Date(),
@@ -284,7 +322,7 @@ const insertData = async (markdownData: MarkdownData) => {
           return (
             mission.startups &&
             mission.startups.length &&
-            db
+            trx
               .insertInto("missions_startups")
               .values(
                 ({ selectFrom }) =>
@@ -302,13 +340,13 @@ const insertData = async (markdownData: MarkdownData) => {
       );
       await pAll(
         author.attributes.teams?.map((team) => async () => {
-          const res = await db
+          const res = await trx
             .selectFrom("teams")
             .where("ghid", "=", team.replace("/teams/", ""))
             .select("uuid")
             .executeTakeFirst();
           if (res) {
-            return db
+            return trx
               .insertInto("users_teams")
               .values({
                 team_id: res.uuid,
@@ -335,9 +373,16 @@ const insertData = async (markdownData: MarkdownData) => {
   });
 };
 
-const importData = async () => {
+export const importData = async () => {
+  assertDestructiveImportAllowed();
   const markdownData = await importFromZip();
-  await insertData(markdownData);
+  await db.transaction().execute(async (trx) => {
+    await insertData(markdownData, trx);
+  });
 };
 
-importData();
+// Only auto-execute when invoked directly as a script (e.g. `node dist/.../import-from-www.js`).
+// Skipping the auto-run when imported (tests) keeps the guard testable in isolation.
+if (require.main === module) {
+  importData();
+}


### PR DESCRIPTION
## 🚨 Audit EXP-1 — script destructif sans garde-fou

Référence : `AUDIT.md` § 5.4 (EXP-1) — item **#5 du plan d'action P0**.

`src/scripts/import-from-www.ts` effectue un **TRUNCATE + ré-INSERT** sur 10 tables (`incubators`, `teams`, `organizations`, `startups`, `missions`, `phases`, `events`, `missions_startups`, `startup_events`, `startups_organizations`). Aucune protection ne l'empêchait jusqu'ici de tourner sur la base **prod**, et les opérations n'étaient **pas wrappées dans une transaction** (un échec partiel laissait la DB amputée — toutes les tables sources déjà vidées).

## 🔧 Correctifs (1 PR)

### 1. Garde-fou environnement

Nouvelle fonction exportée `assertDestructiveImportAllowed(env?)` :

- ❌ **throw** si `NODE_ENV === "production"` et `ALLOW_DESTRUCTIVE_IMPORT` ≠ `"true"`
- ⚠️ **console.warn** quand l'override `ALLOW_DESTRUCTIVE_IMPORT=true` est explicitement posé (peu importe l'env)
- ✅ Pass-through silencieux dans tous les autres cas (dev/test/staging)

### 2. Wrap dans une transaction Kysely

```ts
await db.transaction().execute(async (trx) => {
  await insertData(markdownData, trx);
});
```

`insertData` accepte désormais un `trx: Transaction<DB>` et **toutes** les opérations DB internes (deleteFrom + insertInto, ~30 occurrences) passent par `trx`. Un échec n'importe où dans le pipeline déclenche le rollback complet — y compris le TRUNCATE initial.

### 3. Module testable

- `assertDestructiveImportAllowed`, `insertData` et `importData` sont maintenant **exportés**
- L'auto-exécution est conditionnée à `if (require.main === module)` — l'import depuis un test ne déclenche plus le pipeline réel

## 🧪 Tests (5 cas)

Nouveau `src/scripts/import-from-www.spec.ts` :

| # | Cas | Attendu |
|---|---|---|
| 1 | `NODE_ENV=production`, override absent | throw + pas de warn |
| 2 | `NODE_ENV=production`, override = `"1"` ou `"yes"` | throw |
| 3 | `NODE_ENV=production`, override = `"true"` | pass + warn |
| 4 | `NODE_ENV=development` / `test` / non défini | pass + pas de warn |
| 5 | `NODE_ENV=development`, override = `"true"` | pass + warn |

Proxyquire stube `@/server/config` et `@lib/kysely` pour que la spec tourne sans `.env` ni connexion DB.

```
  import-from-www destructive guard
    ✓ throws when NODE_ENV=production and ALLOW_DESTRUCTIVE_IMPORT is not set
    ✓ throws when NODE_ENV=production and ALLOW_DESTRUCTIVE_IMPORT is not exactly 'true'
    ✓ does not throw when NODE_ENV=production and ALLOW_DESTRUCTIVE_IMPORT='true' (with warning)
    ✓ does not throw in non-production environments
    ✓ warns in non-production envs as well when ALLOW_DESTRUCTIVE_IMPORT=true

  5 passing (5ms)
```

## 📁 Diff

```
 src/scripts/import-from-www.ts      | 101 +++++++++++++++++++------
 src/scripts/import-from-www.spec.ts |  82 +++++++++++++++++++
 2 files changed, 154 insertions(+), 28 deletions(-)
```

## 🔁 Mode opératoire pour ré-importer en prod (cas exceptionnel)

```bash
ALLOW_DESTRUCTIVE_IMPORT=true node dist/src/scripts/import-from-www.js
```

La CI / les déploiements automatiques ne fixent **jamais** cette variable.

## ⏭️ Suite (autres recommandations EXP)

- EXP-2 : check du code de retour `curl --fail` dans `export-to-www.sh`
- EXP-3 : enrichir le commit message avec un résumé du delta
- EXP-4 : exit code ≠ 0 sur erreur Zod
- EXP-7 : tests sur `getChanges()` (pipeline export)

À traiter dans des PR dédiées.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author