### PR TITLE
fix(a11y): make static onClick elements keyboard-accessible (RGAA 7.1 / 7.3)

### DIFF
--- a/__tests__/a11y-keyboard-interactions.spec.ts
+++ b/__tests__/a11y-keyboard-interactions.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+import path from "path";
+
+import { ESLint } from "eslint";
+
+/**
+ * Anti-regression guard for RGAA criteria 7.1 / 7.3 (interactive elements
+ * accessible via keyboard).
+ *
+ * Sixteen warnings (10x click-events-have-key-events + 6x
+ * no-static-element-interactions) lived on:
+ *   - <span onClick> used as action triggers (Community / StartupList)
+ *   - <i onClick> used as a delete button (StartupMembers)
+ *   - third-party MdEditor header plugin (<span> hover menu + <hN onClick>)
+ *
+ * Fixes:
+ *   - <span>/<i> action triggers converted to <button type="button"> with a
+ *     minimal CSS reset to preserve the DSFR fr-link visual.
+ *   - MdEditor plugin: role="button" + tabIndex={0} + onKeyDown/onFocus/
+ *     onBlur added to the existing static elements.
+ *
+ * If any future change reintroduces a static element with onClick but no
+ * keyboard equivalent on these files, this test fails immediately.
+ */
+describe("a11y — keyboard interactions on static elements", () => {
+  const repoRoot = path.resolve(__dirname, "..");
+  const targets = [
+    path.join(repoRoot, "src", "components", "CommunityPage", "Community.tsx"),
+    path.join(
+      repoRoot,
+      "src",
+      "components",
+      "StartupForm",
+      "MdEditorCustomHeaderPlugin.tsx",
+    ),
+    path.join(
+      repoRoot,
+      "src",
+      "components",
+      "StartupListPage",
+      "StartupList.tsx",
+    ),
+    path.join(
+      repoRoot,
+      "src",
+      "components",
+      "StartupPage",
+      "StartupMembers.tsx",
+    ),
+  ];
+
+  it("emits 0 click-events-have-key-events / no-static-element-interactions warnings", async () => {
+    const eslint = new ESLint({ cwd: repoRoot });
+    const results = await eslint.lintFiles(targets);
+    const watched = new Set([
+      "jsx-a11y/click-events-have-key-events",
+      "jsx-a11y/no-static-element-interactions",
+    ]);
+
+    const offending = results.flatMap((r) =>
+      r.messages
+        .filter((m) => m.ruleId !== null && watched.has(m.ruleId))
+        .map(
+          (m) =>
+            `${path.relative(repoRoot, r.filePath)}:${m.line} ${m.ruleId} — ${m.message}`,
+        ),
+    );
+
+    expect(offending, offending.join("\n")).to.have.lengthOf(0);
+  }).timeout(30000);
+});

--- a/src/components/CommunityPage/Community.tsx
+++ b/src/components/CommunityPage/Community.tsx
@@ -76,17 +76,23 @@ const getUserRow = ({
     </>,
     <>{user.primary_email}</>,
     // domaine
-    <span
+    <button
       key="domaine"
+      type="button"
       className={fr.cx("fr-link", "fr-link--sm")}
-      style={{ cursor: "pointer" }}
+      style={{
+        background: "transparent",
+        border: 0,
+        padding: 0,
+        cursor: "pointer",
+      }}
       title="Chercher tous les membres de ce domaine"
       onClick={() => {
         onDomaineClick(user.domaine);
       }}
     >
       {user.domaine}
-    </span>,
+    </button>,
     // teams
     teams.length ? (
       <ul style={{ paddingLeft: 0 }}>

--- a/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
+++ b/src/components/StartupForm/MdEditorCustomHeaderPlugin.tsx
@@ -19,31 +19,79 @@ const Header2Plugin = (props) => {
   const handleHeader = (header) => {
     props.handleHeader(header);
   };
+  const onHeaderKeyDown = (
+    e: React.KeyboardEvent<HTMLHeadingElement>,
+    header: string,
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleHeader(header);
+    }
+  };
   return (
     <span
       className="button button-type-header"
       title={"Header"}
+      role="button"
+      tabIndex={0}
       onMouseEnter={show}
       onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
     >
       <i className={`rmel-iconfont rmel-icon-font-size`} />
       {/* @ts-ignore todo */}
       <DropList show={visible} onClose={hide}>
         <ul className="header-list">
           <li className="list-item">
-            <h2 onClick={() => handleHeader("h2")}>H2</h2>
+            <h2
+              role="button"
+              tabIndex={0}
+              onClick={() => handleHeader("h2")}
+              onKeyDown={(e) => onHeaderKeyDown(e, "h2")}
+            >
+              H2
+            </h2>
           </li>
           <li className="list-item">
-            <h3 onClick={() => handleHeader("h3")}>H3</h3>
+            <h3
+              role="button"
+              tabIndex={0}
+              onClick={() => handleHeader("h3")}
+              onKeyDown={(e) => onHeaderKeyDown(e, "h3")}
+            >
+              H3
+            </h3>
           </li>
           <li className="list-item">
-            <h4 onClick={() => handleHeader("h4")}>H4</h4>
+            <h4
+              role="button"
+              tabIndex={0}
+              onClick={() => handleHeader("h4")}
+              onKeyDown={(e) => onHeaderKeyDown(e, "h4")}
+            >
+              H4
+            </h4>
           </li>
           <li className="list-item">
-            <h5 onClick={() => handleHeader("h5")}>H5</h5>
+            <h5
+              role="button"
+              tabIndex={0}
+              onClick={() => handleHeader("h5")}
+              onKeyDown={(e) => onHeaderKeyDown(e, "h5")}
+            >
+              H5
+            </h5>
           </li>
           <li className="list-item">
-            <h6 onClick={() => handleHeader("h6")}>H6</h6>
+            <h6
+              role="button"
+              tabIndex={0}
+              onClick={() => handleHeader("h6")}
+              onKeyDown={(e) => onHeaderKeyDown(e, "h6")}
+            >
+              H6
+            </h6>
           </li>
         </ul>
       </DropList>

--- a/src/components/StartupListPage/StartupList.tsx
+++ b/src/components/StartupListPage/StartupList.tsx
@@ -59,8 +59,14 @@ const getStartupRow = ({
           ></i>
           {(startup.thematiques || []).map((thematique, idx, all) => (
             <span key={thematique}>
-              <span
-                style={{ cursor: "pointer" }}
+              <button
+                type="button"
+                style={{
+                  background: "transparent",
+                  border: 0,
+                  padding: 0,
+                  cursor: "pointer",
+                }}
                 className={fr.cx("fr-link", "fr-link")}
                 title="Chercher toutes les startups de cette thématique"
                 onClick={() => {
@@ -68,7 +74,7 @@ const getStartupRow = ({
                 }}
               >
                 {thematique}
-              </span>
+              </button>
               {idx < all.length - 1 && ", "}
             </span>
           ))}
@@ -83,8 +89,14 @@ const getStartupRow = ({
           ></i>
           {(startup.usertypes || []).map((usertype, idx, all) => (
             <span key={usertype}>
-              <span
-                style={{ cursor: "pointer" }}
+              <button
+                type="button"
+                style={{
+                  background: "transparent",
+                  border: 0,
+                  padding: 0,
+                  cursor: "pointer",
+                }}
                 className={fr.cx("fr-link", "fr-link")}
                 title="Chercher toutes les startups pour ces utilisateurs"
                 onClick={() => {
@@ -92,7 +104,7 @@ const getStartupRow = ({
                 }}
               >
                 {usertype}
-              </span>
+              </button>
               {idx < all.length - 1 && ", "}
             </span>
           )) || null}
@@ -101,8 +113,14 @@ const getStartupRow = ({
         null}
     </>,
     startup.incubatorId && (
-      <span
-        style={{ cursor: "pointer" }}
+      <button
+        type="button"
+        style={{
+          background: "transparent",
+          border: 0,
+          padding: 0,
+          cursor: "pointer",
+        }}
         className={fr.cx("fr-link", "fr-link")}
         title="Chercher toutes les startups de cet incubateur"
         onClick={() => {
@@ -110,7 +128,7 @@ const getStartupRow = ({
         }}
       >
         {startup.incubatorName}
-      </span>
+      </button>
     ),
   ];
 };

--- a/src/components/StartupPage/StartupMembers.tsx
+++ b/src/components/StartupPage/StartupMembers.tsx
@@ -53,11 +53,22 @@ export function MemberTable({
             ),
           ) || "",
           canEditMembers && (
-            <i
+            <button
+              type="button"
+              aria-label={`Retirer ${member.fullname || member.username} de la startup`}
               onClick={(e) => onRemoveMemberClick(e, member)}
-              className={fr.cx("fr-icon--md", "ri-delete-bin-2-fill")}
-              style={{ cursor: "pointer" }}
-            ></i>
+              style={{
+                background: "transparent",
+                border: 0,
+                padding: 0,
+                cursor: "pointer",
+              }}
+            >
+              <i
+                className={fr.cx("fr-icon--md", "ri-delete-bin-2-fill")}
+                aria-hidden="true"
+              ></i>
+            </button>
           ),
         ])}
       headers={["Nom", "Role", "Date d'arrivée", "Date de fin", "Actions"]}


### PR DESCRIPTION
## ♿ RGAA 7.1 / 7.3 — interactions clavier

16 warnings supprimés : **10x** `jsx-a11y/click-events-have-key-events` + **6x** `jsx-a11y/no-static-element-interactions` (baseline #1355).

## 🔧 Correctifs

| Fichier | Type | Fix |
|---|---|---|
| `Community.tsx` | `<span onClick>` action | → `<button type="button">` + reset CSS minimal |
| `StartupList.tsx` (3x) | `<span onClick>` action | → `<button type="button">` + reset CSS minimal |
| `StartupMembers.tsx` | `<i onClick>` delete | → `<button>` wrapper + `aria-label` explicite |
| `MdEditorCustomHeaderPlugin.tsx` | code tiers (port) | `role="button"` + `tabIndex` + `onFocus/onBlur` (hover trigger) + `onKeyDown` Enter/Space (`<hN>`) |

Le DSFR `fr-link` est conservé visuellement grâce au reset `background/border/padding` sur les nouveaux `<button>`.

Approche minimale-diff sur le plugin MdEditor (code porté depuis [HarryChen0506/react-markdown-editor-lite](https://github.com/HarryChen0506/react-markdown-editor-lite)) pour limiter l'impact visuel sur la toolbar de l'éditeur.

## 🧪 Tests

Nouveau `__tests__/a11y-keyboard-interactions.spec.ts` (même pattern que #1361 / #1363) : asserte **0** warning des deux règles sur les 4 fichiers patchés via l'API ESLint.

```
  a11y — keyboard interactions on static elements
    ✓ emits 0 click-events-have-key-events / no-static-element-interactions warnings (3740ms)

  1 passing (4s)
```

## 📊 Compteur RGAA

- Baseline (PR #1355) : **29** warnings `jsx-a11y`
- Après #1361 (`html-has-lang`) : 27
- Après #1363 (`label-has-associated-control`) : 22
- **Après cette PR : 6** ✨

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author