### PR TITLE
fix(phases): align labels with beta.gouv.fr

### DIFF
--- a/src/models/startup.ts
+++ b/src/models/startup.ts
@@ -16,14 +16,14 @@ export enum StartupPhase {
 }
 
 export const PHASE_READABLE_NAME: Record<StartupPhase, string> = {
-  investigation: "Investigation",
-  acceleration: "Accélération",
-  construction: "Construction",
-  perennisation: "En cours de pérennisation",
+  investigation: "En investigation",
+  acceleration: "En accélération",
+  construction: "En construction",
+  perennisation: "En consolidation",
   transfere: "Transféré",
-  opere: "Opéré par beta.gouv.fr",
-  abandon: "Abandonné",
-  "abandon-investigation": "Abandonné après investigation",
+  opere: "Opéré au sein du réseau",
+  abandon: "Arrêté",
+  "abandon-investigation": "Investigation non concluante",
 };
 
 export const PHASES_ORDERED_LIST = [


### PR DESCRIPTION
Following https://github.com/betagouv/beta.gouv.fr/issues/21553

Align phases readable names with website

<img width="206" height="218" alt="Capture d’écran 2026-05-20 à 22 18 25" src="https://github.com/user-attachments/assets/151496a3-9b3e-4081-960d-1ad9494ce407" />

