### PR TITLE
feat: add startups.contact_dinum and startups.contact_incubator

### DIFF
--- a/migrations/20260617000001_add_contact_fields_to_startups.ts
+++ b/migrations/20260617000001_add_contact_fields_to_startups.ts
@@ -1,0 +1,21 @@
+export async function up(knex) {
+    await knex.schema.alterTable("startups", (table) => {
+        table
+            .uuid("contact_dinum")
+            .nullable()
+            .references("uuid")
+            .inTable("users");
+        table
+            .uuid("contact_incubator")
+            .nullable()
+            .references("uuid")
+            .inTable("users");
+    });
+}
+
+export async function down(knex) {
+    await knex.schema.alterTable("startups", (table) => {
+        table.dropColumn("contact_dinum");
+        table.dropColumn("contact_incubator");
+    });
+}

--- a/src/@types/db.d.ts
+++ b/src/@types/db.d.ts
@@ -366,6 +366,8 @@ export interface Startups {
   analyse_risques_url: string | null;
   budget_url: string | null;
   contact: string | null;
+  contact_dinum: string | null;
+  contact_incubator: string | null;
   created_at: Generated<Timestamp>;
   dashlord_url: string | null;
   description: string | null;

--- a/src/app/(private)/(dashboard)/startups/[id]/info-form/page.tsx
+++ b/src/app/(private)/(dashboard)/startups/[id]/info-form/page.tsx
@@ -9,6 +9,7 @@ import { StartupInfoUpdate } from "@/components/StartupInfoUpdatePage";
 import { getEventListByStartupUuid } from "@/lib/events";
 import { db } from "@/lib/kysely";
 import { getStartup } from "@/lib/kysely/queries";
+import { getActiveUsers } from "@/lib/kysely/queries/users";
 import s3 from "@/lib/s3";
 import { startupChangeToModel, startupToModel } from "@/models/mapper";
 import { sponsorSchema } from "@/models/sponsor";
@@ -55,6 +56,11 @@ export default async function Page(props) {
 
   const incubators = await db.selectFrom("incubators").selectAll().execute(); //await betagouv.incubators();
   const sponsors = await db.selectFrom("organizations").selectAll().execute(); //await betagouv.sponsors();
+  const activeUsers = await getActiveUsers()
+    .clearSelect()
+    .select(["users.uuid", "users.fullname"])
+    .groupBy(["users.uuid", "users.fullname"])
+    .execute();
   const startup = startupToModel(await getStartup(query));
   if (!startup) {
     redirect("/startups");
@@ -150,6 +156,10 @@ export default async function Page(props) {
         label: incubator.name,
       };
     }),
+    memberOptions: activeUsers.map((u) => ({
+      value: u.uuid,
+      label: u.fullname,
+    })),
     changes: changes.map((change) => startupChangeToModel(change)),
   };
 

--- a/src/app/(private)/(dashboard)/startups/[id]/page.tsx
+++ b/src/app/(private)/(dashboard)/startups/[id]/page.tsx
@@ -124,7 +124,8 @@ export default async function Page({ params }: Props) {
   // for the "add member select"
   const allMembers = await getActiveUsers()
     .clearSelect()
-    .select(["username", "fullname", "id"])
+    .select(["users.username", "users.fullname", "users.uuid"])
+    .groupBy(["users.username", "users.fullname", "users.uuid"])
     .execute();
 
   const canEditMembers = await canEditStartup(session, dbSe.uuid);

--- a/src/app/(private)/(dashboard)/startups/create-form/page.tsx
+++ b/src/app/(private)/(dashboard)/startups/create-form/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 
 import { StartupInfoCreate } from "@/components/StartupInfoCreatePage";
 import { db } from "@/lib/kysely";
+import { getActiveUsers } from "@/lib/kysely/queries/users";
 import betagouv from "@/server/betagouv";
 import { routeTitles } from "@/utils/routes/routeTitles";
 
@@ -12,6 +13,11 @@ export const metadata: Metadata = {
 export default async function Page(props) {
   const incubators = await db.selectFrom("incubators").selectAll().execute(); //await betagouv.incubators();
   const sponsors = await db.selectFrom("organizations").selectAll().execute(); //await betagouv.sponsors();
+  const activeUsers = await getActiveUsers()
+    .clearSelect()
+    .select(["users.uuid", "users.fullname"])
+    .groupBy(["users.uuid", "users.fullname"])
+    .execute();
 
   return (
     <>
@@ -29,6 +35,10 @@ export default async function Page(props) {
             label: incubator.name,
           };
         })}
+        memberOptions={activeUsers.map((u) => ({
+          value: u.uuid,
+          label: u.fullname,
+        }))}
         {...props}
       />
     </>

--- a/src/components/StartupForm/StartupForm.tsx
+++ b/src/components/StartupForm/StartupForm.tsx
@@ -20,6 +20,7 @@ import SponsorBlock from "./SponsorBlock";
 import { TechnoEditor } from "./TechnoEditor";
 import { ThematiquesEditor } from "./ThematiquesEditor";
 import { UsertypesEditor } from "./UsertypesEditor";
+import AutoComplete from "../AutoComplete";
 import { ClientOnly } from "../ClientOnly";
 import UploadForm from "../UploadForm/UploadForm";
 import { ActionResponse } from "@/@types/serverAction";
@@ -87,6 +88,7 @@ export interface StartupFormProps {
   startupEvents?: eventSchemaType[];
   incubatorOptions: Option[];
   sponsorOptions: Option[];
+  memberOptions: Option[];
   save: (data: startupInfoUpdateSchemaType) => Promise<ActionResponse>;
 }
 
@@ -466,6 +468,87 @@ export function StartupForm(props: StartupFormProps) {
               </option>
             ))}
           </Select>
+          <div className="fr-select-group">
+            <label className="fr-label">
+              {
+                startupInfoUpdateSchema.shape.startup.shape.contact_dinum
+                  .description
+              }
+              <span className="fr-hint-text">
+                Responsable DINUM référent pour ce produit
+              </span>
+            </label>
+            <AutoComplete
+              options={props.memberOptions.map((m) => ({
+                id: m.value,
+                label: m.label,
+              }))}
+              autoComplete={true}
+              onSelect={(selected) => {
+                setValue(
+                  "startup.contact_dinum",
+                  (selected as any)?.id || null,
+                  { shouldDirty: true },
+                );
+              }}
+              defaultValue={
+                props.startup?.contact_dinum
+                  ? (props.memberOptions
+                      .filter((m) => m.value === props.startup?.contact_dinum)
+                      .map((m) => ({ id: m.value, label: m.label }))[0] ?? null)
+                  : null
+              }
+              optionKeyField="id"
+              multiple={false}
+              placeholder="Sélectionner un contact"
+            />
+            {errors?.startup?.contact_dinum && (
+              <p className="fr-error-text">
+                {errors.startup.contact_dinum.message as string}
+              </p>
+            )}
+          </div>
+          <div className="fr-select-group">
+            <label className="fr-label">
+              {
+                startupInfoUpdateSchema.shape.startup.shape.contact_incubator
+                  .description
+              }
+              <span className="fr-hint-text">
+                Responsable incubateur référent pour ce produit
+              </span>
+            </label>
+            <AutoComplete
+              options={props.memberOptions.map((m) => ({
+                id: m.value,
+                label: m.label,
+              }))}
+              onSelect={(selected) => {
+                setValue(
+                  "startup.contact_incubator",
+                  (selected as any)?.id || null,
+                  { shouldDirty: true },
+                );
+              }}
+              defaultValue={
+                props.startup?.contact_incubator
+                  ? (props.memberOptions
+                      .filter(
+                        (m) => m.value === props.startup?.contact_incubator,
+                      )
+                      .map((m) => ({ id: m.value, label: m.label }))[0] ?? null)
+                  : null
+              }
+              optionKeyField="id"
+              multiple={false}
+              placeholder="Sélectionner un contact"
+            />
+            {errors?.startup?.contact_incubator && (
+              <p className="fr-error-text">
+                {errors.startup.contact_incubator.message as string}
+              </p>
+            )}
+          </div>
           <SponsorBlock
             sponsors={sponsors}
             allSponsors={allSponsors}

--- a/src/components/StartupInfoCreatePage/StartupInfoCreate.tsx
+++ b/src/components/StartupInfoCreatePage/StartupInfoCreate.tsx
@@ -15,6 +15,7 @@ import { saveImage } from "@/utils/file";
 interface StartupInfoCreateProps {
   incubatorOptions: Option[];
   sponsorOptions: Option[];
+  memberOptions: Option[];
 }
 
 /* Pure component */
@@ -93,6 +94,7 @@ export const StartupInfoCreate = (props: StartupInfoCreateProps) => {
           save={save}
           incubatorOptions={props.incubatorOptions}
           sponsorOptions={props.sponsorOptions}
+          memberOptions={props.memberOptions}
         />
         <br />
         <br />

--- a/src/components/StartupInfoUpdatePage/StartupInfoUpdate.tsx
+++ b/src/components/StartupInfoUpdatePage/StartupInfoUpdate.tsx
@@ -27,6 +27,7 @@ interface StartupInfoUpdateProps {
   startupEvents: eventSchemaType[];
   incubatorOptions: Option[];
   sponsorOptions: Option[];
+  memberOptions: Option[];
   heroURL?: string;
   shotURL?: string;
   changes: StartupChangeSchemaType[];
@@ -125,6 +126,7 @@ export const StartupInfoUpdate = (props: StartupInfoUpdateProps) => {
             shotURL={props.shotURL}
             incubatorOptions={props.incubatorOptions}
             sponsorOptions={props.sponsorOptions}
+            memberOptions={props.memberOptions}
           />
         )) || <>Loading...</>}
       </div>

--- a/src/components/StartupPage/StartupMembers.tsx
+++ b/src/components/StartupPage/StartupMembers.tsx
@@ -84,9 +84,15 @@ export const StartupMembers = ({
 }: {
   startupInfos: startupSchemaType;
   members: memberSchemaType[];
-  allMembers: { username: string; fullname: string }[];
+  allMembers: { username: string; fullname: string; uuid: string }[];
   canEditMembers: boolean;
 }) => {
+  const contactDinum = allMembers.find(
+    (m) => m.uuid === startupInfos.contact_dinum,
+  );
+  const contactIncubator = allMembers.find(
+    (m) => m.uuid === startupInfos.contact_incubator,
+  );
   const [showAddMember, setShowAddMember] = useState(false);
   const router = useRouter();
 
@@ -151,6 +157,27 @@ export const StartupMembers = ({
           l'équipe
         </a>
       </div>
+      {(contactDinum || contactIncubator) && (
+        <div className={fr.cx("fr-mb-4w")}>
+          <h3>Points de contact</h3>
+          {contactDinum && (
+            <p>
+              <strong>Point de contact DINUM :</strong>{" "}
+              <a href={`/community/${contactDinum.username}`}>
+                {contactDinum.fullname}
+              </a>
+            </p>
+          )}
+          {contactIncubator && (
+            <p>
+              <strong>Point de contact Incubateur :</strong>{" "}
+              <a href={`/community/${contactIncubator.username}`}>
+                {contactIncubator.fullname}
+              </a>
+            </p>
+          )}
+        </div>
+      )}
       {(activeMembers.length && (
         <Accordion
           titleAs="h2"

--- a/src/components/StartupPage/StartupPage.tsx
+++ b/src/components/StartupPage/StartupPage.tsx
@@ -31,6 +31,7 @@ export interface StartupPageProps {
   allMembers: {
     fullname: string;
     username: string;
+    uuid: string;
   }[];
   members: memberBaseInfoSchemaType[];
   phases: phaseSchemaType[];

--- a/src/models/actions/startup.ts
+++ b/src/models/actions/startup.ts
@@ -9,6 +9,8 @@ export const startupInfoUpdateSchema = z.object({
     name: startupSchema.shape.name,
     pitch: startupSchema.shape.pitch,
     incubator_id: startupSchema.shape.incubator_id,
+    contact_dinum: startupSchema.shape.contact_dinum,
+    contact_incubator: startupSchema.shape.contact_incubator,
     contact: startupSchema.shape.contact,
     link: startupSchema.shape.link,
     repository: startupSchema.shape.repository,

--- a/src/models/startup.ts
+++ b/src/models/startup.ts
@@ -153,6 +153,18 @@ export const startupSchema = z.object({
     })
     .min(1)
     .describe("Incubateur ou fabrique numérique"),
+  contact_dinum: z
+    .preprocess(
+      (val) => (val === "" ? null : val),
+      z.string().uuid().nullable().optional(),
+    )
+    .describe("Point de contact DINUM"),
+  contact_incubator: z
+    .preprocess(
+      (val) => (val === "" ? null : val),
+      z.string().uuid().nullable().optional(),
+    )
+    .describe("Point de contact Incubateur"),
   contact: z
     .string({
       errorMap: () => ({

--- a/src/scripts/github-schemas.ts
+++ b/src/scripts/github-schemas.ts
@@ -79,6 +79,8 @@ const domaines = [
   "Data",
   "Support",
   "Autre",
+  "Attributaire",
+  "Data",
 ] as const;
 
 const preventDuplicates = (val, ctx) => {

--- a/src/scripts/update-local-files.ts
+++ b/src/scripts/update-local-files.ts
@@ -95,11 +95,23 @@ const getChanges = async (markdownData) => {
       "startups_organizations.organization_id",
     )
     .leftJoin("incubators", "incubators.uuid", "startups.incubator_id")
+    .leftJoin(
+      "users as dinum_contact",
+      "dinum_contact.uuid",
+      "startups.contact_dinum",
+    )
+    .leftJoin(
+      "users as incub_contact",
+      "incub_contact.uuid",
+      "startups.contact_incubator",
+    )
     .select((eb) => [
       ...startupColumns,
       eb.ref("startups.name").as("title"),
       eb.ref("startups.pitch").as("mission"),
       eb.ref("incubators.ghid").as("incubator"),
+      eb.ref("dinum_contact.username").as("contact_dinum"),
+      eb.ref("incub_contact.username").as("contact_incubator"),
       sql<
         Array<string>
       >`COALESCE(NULLIF(ARRAY_AGG(CONCAT('/organisations/', organizations.ghid) order by organizations.ghid), '{/organisations/}'), '{}')`.as(
@@ -108,7 +120,13 @@ const getChanges = async (markdownData) => {
       withPhases(eb),
       withEvents(eb),
     ])
-    .groupBy([...startupColumns, "startups.uuid", "incubators.ghid"])
+    .groupBy([
+      ...startupColumns,
+      "startups.uuid",
+      "incubators.ghid",
+      "dinum_contact.username",
+      "incub_contact.username",
+    ])
     .execute();
 
   const userColumns = [


### PR DESCRIPTION
Ça apparait comme ceci dans le formulaire du produit :

<img width="835" height="356" alt="Capture d’écran 2026-06-18 à 23 07 18" src="https://github.com/user-attachments/assets/0600308d-8d21-4fd1-afd0-3c86835ad002" />

Comme cela dans la fiche produit de l'espace membre :

<img width="828" height="409" alt="Capture d’écran 2026-06-18 à 23 07 05" src="https://github.com/user-attachments/assets/233bf92a-f971-4dae-9cf8-afffd6e2c1c1" />

Le champ est exporté dans les fiches du site web si besoin

<img width="270" height="113" alt="Capture d’écran 2026-06-18 à 23 21 46" src="https://github.com/user-attachments/assets/b0ec49fa-21c8-459e-8119-c28f3aeaaabc" />
