### PR TITLE
modif: status des comptes passe a Outils et supp de mails bounce

### DIFF
--- a/src/components/MemberPage/MemberPage.tsx
+++ b/src/components/MemberPage/MemberPage.tsx
@@ -213,7 +213,7 @@ export default function MemberPage({
       ),
     },
     {
-      label: "Statut des comptes",
+      label: "Outils",
       tabId: "statut-comptes",
       isDefault: tab === "statut-comptes",
 

--- a/src/models/ops.ts
+++ b/src/models/ops.ts
@@ -14,7 +14,6 @@ export enum OPS_DEMANDE_TYPE {
   MAILING_LIST = "Création d'une mailing list @beta.gouv.fr",
   TALLY = "Création d'un compte tally",
   AUTRE = "Autre",
-  EMAIL_BOUNCE = "Mon email bounce",
 }
 
 // Order shown in the form (matches the airtable form).
@@ -27,7 +26,6 @@ export const OPS_DEMANDE_CHOICES: OPS_DEMANDE_TYPE[] = [
   OPS_DEMANDE_TYPE.SENTRY,
   OPS_DEMANDE_TYPE.UPDOWN,
   OPS_DEMANDE_TYPE.TALLY,
-  OPS_DEMANDE_TYPE.EMAIL_BOUNCE,
   OPS_DEMANDE_TYPE.AUTRE,
 ];
 
@@ -117,7 +115,6 @@ export const OPS_DEMANDE_FIELDS: Record<OPS_DEMANDE_TYPE, OpsFieldKey[]> = {
   [OPS_DEMANDE_TYPE.TALLY]: ["commentaires"],
   [OPS_DEMANDE_TYPE.SSL_CERTIGNA]: ["commentaires"],
   [OPS_DEMANDE_TYPE.MAILING_LIST]: ["commentaires"],
-  [OPS_DEMANDE_TYPE.EMAIL_BOUNCE]: ["commentaires"],
   [OPS_DEMANDE_TYPE.AUTRE]: ["commentaires"],
 };
 
@@ -127,7 +124,6 @@ export const OPS_DEMANDE_COMMENT_REQUIRED: OPS_DEMANDE_TYPE[] = [
   OPS_DEMANDE_TYPE.CLOUD_RESOURCES,
   OPS_DEMANDE_TYPE.DNS_RECORD,
   OPS_DEMANDE_TYPE.TALLY,
-  OPS_DEMANDE_TYPE.EMAIL_BOUNCE,
 ];
 
 export enum OPS_STATUT {


### PR DESCRIPTION
## Modifications

  - Formulaire « Demandes d'OPS » : suppression de l'option « Mon email bounce » (retrait de
  l'enum `OPS_DEMANDE_TYPE.EMAIL_BOUNCE` et de ses références dans `CHOICES`,
  `OPS_DEMANDE_FIELDS` et `OPS_DEMANDE_COMMENT_REQUIRED`).
  - Fiche membre : renommage de l'onglet « Statut des comptes » en « Outils ».

  ## Fichiers touchés

  - `src/models/ops.ts`
  - `src/components/MemberPage/MemberPage.tsx`