### PR TITLE
fix: search startups by suivi

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "e2e": "npx playwright test",
     "test": "NODE_ENV=test ts-mocha --paths -p tsconfig.json src/**/*.spec.ts __tests__/*.ts --exit --require ts-node/register --require ts-node/esm --icu-data-dir=./node_modules/full-icu --require ./__tests__/env-setup.ts --timeout 30000",
     "seed": "NODE_OPTIONS='--import tsx/esm' knex seed:run",
-    "predev": "only-include-used-icons",
-    "prebuild": "only-include-used-icons",
     "postinstall": "is-ci || husky install",
     "kysely-codegen": "./node_modules/.bin/kysely-codegen --include-pattern=\"(public|pgboss).*\" --out-file ./src/@types/db.d.ts",
     "staging-import-from-www": "node dist/src/scripts/import-from-www",

--- a/src/components/StartupListPage/StartupList.tsx
+++ b/src/components/StartupListPage/StartupList.tsx
@@ -157,6 +157,13 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
             return result.incubatorId === filter.value.toString();
           } else if (filter.type === "techno" && filter.value) {
             return (result.techno || []).includes(filter.value.toString());
+          } else if (filter.type === "contact" && filter.value) {
+            return (
+              result.contact_dinum === filter.value ||
+              result.contact_incubator === filter.value
+            );
+          } else if (filter.type === "sans_suivi_dinum") {
+            return !result.contact_dinum;
           }
         }).length === filters.length // or > 0 for or query
       );
@@ -203,6 +210,33 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
     .sort()
     .map((t) => ({ id: t, label: t }));
 
+  const allContacts = useMemo(() => {
+    const seen = new Set<string>();
+    const contacts: { id: string; label: string }[] = [];
+    for (const s of startups) {
+      if (
+        s.contact_dinum &&
+        s.contact_dinum_fullname &&
+        !seen.has(s.contact_dinum)
+      ) {
+        seen.add(s.contact_dinum);
+        contacts.push({ id: s.contact_dinum, label: s.contact_dinum_fullname });
+      }
+      if (
+        s.contact_incubator &&
+        s.contact_incubator_fullname &&
+        !seen.has(s.contact_incubator)
+      ) {
+        seen.add(s.contact_incubator);
+        contacts.push({
+          id: s.contact_incubator,
+          label: s.contact_incubator_fullname,
+        });
+      }
+    }
+    return contacts.sort((a, b) => a.label.localeCompare(b.label));
+  }, [startups]);
+
   const searchOptions = useMemo(
     () => [
       ...Object.entries(PHASE_READABLE_NAME).map(([id, label]) => ({
@@ -217,12 +251,6 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
         id: s.uuid,
         label: s.title,
       })),
-      ...startups.map((s) => ({
-        type: "startup",
-        group: "Startups",
-        id: s.uuid,
-        label: s.name,
-      })),
       ...allThematiques.map((s) => ({
         type: "thematique",
         group: "Thématiques",
@@ -235,6 +263,24 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
         id: s.id,
         label: s.label,
       })),
+      {
+        type: "sans_suivi_dinum",
+        group: "Suivi",
+        id: "sans_suivi_dinum",
+        label: "Sans suivi DINUM",
+      },
+      ...allContacts.map((c) => ({
+        type: "contact",
+        group: "Suivie par",
+        id: c.id,
+        label: c.label,
+      })),
+      ...startups.map((s) => ({
+        type: "startup",
+        group: "Startups",
+        id: s.uuid,
+        label: s.name,
+      })),
       ...allTechnos.map((s) => ({
         type: "techno",
         group: "Technologies",
@@ -242,7 +288,7 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
         label: s.label,
       })),
     ],
-    [],
+    [allContacts],
   );
 
   const defaultFilterValue = searchOptions

--- a/src/components/StartupListPage/StartupList.tsx
+++ b/src/components/StartupListPage/StartupList.tsx
@@ -164,6 +164,8 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
             );
           } else if (filter.type === "sans_suivi_dinum") {
             return !result.contact_dinum;
+          } else if (filter.type === "sans_suivi_incubateur") {
+            return !result.contact_incubator;
           }
         }).length === filters.length // or > 0 for or query
       );
@@ -269,9 +271,15 @@ export const StartupList = ({ startups, incubators }: StartupListProps) => {
         id: "sans_suivi_dinum",
         label: "Sans suivi DINUM",
       },
+      {
+        type: "sans_suivi_incubateur",
+        group: "Suivi",
+        id: "sans_suivi_incubateur",
+        label: "Sans suivi incubateur",
+      },
       ...allContacts.map((c) => ({
         type: "contact",
-        group: "Suivie par",
+        group: "Suivi par",
         id: c.id,
         label: c.label,
       })),

--- a/src/components/StartupListPage/utils.ts
+++ b/src/components/StartupListPage/utils.ts
@@ -11,6 +11,7 @@ export const startupsFilterSchema = z.object({
     "phase",
     "contact",
     "sans_suivi_dinum",
+    "sans_suivi_incubateur",
   ]),
   value: z.union([z.string(), z.boolean()]).optional(),
 });

--- a/src/components/StartupListPage/utils.ts
+++ b/src/components/StartupListPage/utils.ts
@@ -9,6 +9,8 @@ export const startupsFilterSchema = z.object({
     "incubator",
     "startup",
     "phase",
+    "contact",
+    "sans_suivi_dinum",
   ]),
   value: z.union([z.string(), z.boolean()]).optional(),
 });

--- a/src/lib/kysely/queries/startups.ts
+++ b/src/lib/kysely/queries/startups.ts
@@ -106,19 +106,34 @@ const selectLastStartupPhase = (selectFrom, startupId) =>
 export const getAllStartupsWithIncubatorAndPhase = async () => {
   const incubators = await getAllIncubators();
   // todo: better typing
-  const baseSelect = db
+  const startupsData = await db
     .selectFrom("startups")
+    .leftJoin(
+      "users as dinum_contact",
+      "dinum_contact.uuid",
+      "startups.contact_dinum",
+    )
+    .leftJoin(
+      "users as incub_contact",
+      "incub_contact.uuid",
+      "startups.contact_incubator",
+    )
     .select([
-      "uuid",
-      "ghid",
-      "name",
-      "pitch",
-      "thematiques",
-      "techno",
-      "incubator_id",
-      "usertypes",
-    ]);
-  const startupsData = await baseSelect
+      "startups.uuid",
+      "startups.ghid",
+      "startups.name",
+      "startups.pitch",
+      "startups.thematiques",
+      "startups.techno",
+      "startups.incubator_id",
+      "startups.usertypes",
+      "startups.contact_dinum",
+      "startups.contact_incubator",
+    ])
+    .select((eb) => [
+      eb.ref("dinum_contact.fullname").as("contact_dinum_fullname"),
+      eb.ref("incub_contact.fullname").as("contact_incubator_fullname"),
+    ])
     .select(({ selectFrom }) =>
       selectLastStartupPhase(selectFrom, "startups.uuid")
         .orderBy("start", "desc")
@@ -127,14 +142,25 @@ export const getAllStartupsWithIncubatorAndPhase = async () => {
     )
     .execute();
 
+  type StartupsDataRow = (typeof startupsData)[number] & {
+    phase: string | null;
+    contact_dinum_fullname: string | null;
+    contact_incubator_fullname: string | null;
+  };
+
   const startups = startupsData.map((s) => {
+    const row = s as StartupsDataRow;
     const incubator = incubators.find((i) => i.uuid === s.incubator_id);
     return {
       ...s,
-      phase: (s as typeof s & { phase: string | null }).phase,
+      phase: row.phase,
       thematiques: (s.thematiques as string[]) || [],
       techno: (s.techno as string[]) || [],
       usertypes: (s.usertypes as string[]) || [],
+      contact_dinum: s.contact_dinum,
+      contact_incubator: s.contact_incubator,
+      contact_dinum_fullname: row.contact_dinum_fullname,
+      contact_incubator_fullname: row.contact_incubator_fullname,
       incubatorName: incubator && incubator.title,
       incubatorId: s.incubator_id,
     };


### PR DESCRIPTION
Suite à l'ajout des contacts DINUM et incubateur dans les fiches,

Ajout d'un filtre dans la recherche de produit:

 
<img width="245" height="238" alt="Capture d’écran 2026-06-24 à 13 17 37" src="https://github.com/user-attachments/assets/88ef5ca3-d929-458b-860c-8bc13d21179f" />


 - sans suivi DINUM: affiche toutes les fiches sans contact dinum
 - sans suivi incubateur: affiche toutes les fiches sans contact incubateur
 - suivi par XXX: affiche les fiches suivies par XXX