### PR TITLE
ajout d un champ sur le choix scalingo

### DIFF
--- a/src/components/Service/OpsRequestForm.tsx
+++ b/src/components/Service/OpsRequestForm.tsx
@@ -119,6 +119,28 @@ export const OpsRequestForm = ({ defaultValues }: OpsRequestFormProps) => {
         {fields.map((key) => {
           const field = OPS_FIELDS[key];
           const error = errors[key];
+          if (field.type === "select") {
+            return (
+              <RadioButtons
+                key={key}
+                legend={field.label}
+                hintText={field.hint}
+                state={error ? "error" : undefined}
+                stateRelatedMessage={error?.message}
+                options={(field.options ?? []).map((option) => ({
+                  label:
+                    option === field.defaultValue
+                      ? `${option} (recommandé)`
+                      : option,
+                  nativeInputProps: {
+                    value: option,
+                    defaultChecked: option === field.defaultValue,
+                    ...register(key),
+                  },
+                }))}
+              />
+            );
+          }
           if (field.type === "textarea") {
             return (
               <Input

--- a/src/models/actions/opsRequest.ts
+++ b/src/models/actions/opsRequest.ts
@@ -23,6 +23,7 @@ export const opsRequestSchema = z
     projet: z.string().optional(),
     // Per-demande conditional fields (see OPS_DEMANDE_FIELDS).
     nomApp: z.string().optional(),
+    zoneScalingo: z.string().optional(),
     emailCollaborateur: z.string().optional(),
     handleOvh: z.string().optional(),
     zoneDns: z.string().optional(),

--- a/src/models/ops.ts
+++ b/src/models/ops.ts
@@ -57,7 +57,7 @@ export const OPS_FIELDS: Record<OpsFieldKey, OpsField> = {
   zoneScalingo: {
     key: "zoneScalingo",
     label: "Zone Scalingo",
-    hint: "SecNum est recommandé (zone SecNumCloud, plus sécurisée). Choisis osc-fr1 uniquement si ton app a des contraintes techniques incompatibles.",
+    hint: "osc-secnum-fr1 est recommandé (zone SecNumCloud, plus sécurisée). Choisis osc-fr1 uniquement si tu es en dev/preprod et n'exploite pas de données sensibles.",
     type: "select",
     options: ["SecNum", "osc-fr1"],
     defaultValue: "SecNum",

--- a/src/models/ops.ts
+++ b/src/models/ops.ts
@@ -32,12 +32,17 @@ export interface OpsField {
   key: string;
   label: string;
   hint?: string;
-  type?: "text" | "email" | "textarea";
+  type?: "text" | "email" | "textarea" | "select";
+  // Options for the "select" type (rendered as radio buttons).
+  options?: string[];
+  // Default-checked option for the "select" type.
+  defaultValue?: string;
   required?: boolean;
 }
 
 export type OpsFieldKey =
   | "nomApp"
+  | "zoneScalingo"
   | "emailCollaborateur"
   | "handleOvh"
   | "zoneDns"
@@ -49,6 +54,15 @@ export type OpsFieldKey =
 
 export const OPS_FIELDS: Record<OpsFieldKey, OpsField> = {
   nomApp: { key: "nomApp", label: "Nom de l'app à créer", required: true },
+  zoneScalingo: {
+    key: "zoneScalingo",
+    label: "Zone Scalingo",
+    hint: "SecNum est recommandé (zone SecNumCloud, plus sécurisée). Choisis osc-fr1 uniquement si ton app a des contraintes techniques incompatibles.",
+    type: "select",
+    options: ["SecNum", "osc-fr1"],
+    defaultValue: "SecNum",
+    required: true,
+  },
   emailCollaborateur: {
     key: "emailCollaborateur",
     label: "Email à indiquer en collaborateur",
@@ -97,6 +111,7 @@ export const OPS_FIELDS: Record<OpsFieldKey, OpsField> = {
 export const OPS_DEMANDE_FIELDS: Record<OPS_DEMANDE_TYPE, OpsFieldKey[]> = {
   [OPS_DEMANDE_TYPE.SCALINGO_APP]: [
     "nomApp",
+    "zoneScalingo",
     "emailCollaborateur",
     "commentaires",
   ],

--- a/src/models/ops.ts
+++ b/src/models/ops.ts
@@ -59,8 +59,8 @@ export const OPS_FIELDS: Record<OpsFieldKey, OpsField> = {
     label: "Zone Scalingo",
     hint: "osc-secnum-fr1 est recommandé (zone SecNumCloud, plus sécurisée). Choisis osc-fr1 uniquement si tu es en dev/preprod et n'exploite pas de données sensibles.",
     type: "select",
-    options: ["SecNum", "osc-fr1"],
-    defaultValue: "SecNum",
+    options: ["osc-secnum-fr1", "osc-fr1"],
+    defaultValue: "osc-secnum-fr1",
     required: true,
   },
   emailCollaborateur: {


### PR DESCRIPTION
- Nouveau champ `zoneScalingo` (radio) : **SecNum** / **osc-fr1**
- SecNum pré-coché par défaut + libellé « (recommandé) »
- Texte d'aide : SecNum = zone SecNumCloud (plus sécurisée), osc-fr1 seulement en cas de contrainte technique
- La valeur remonte automatiquement dans Grist via la colonne `Demande_libre` (pas de nouvelle colonne)

## Fichiers

- `src/models/ops.ts` — champ `zoneScalingo`, type `select` + `options`/`defaultValue`
- `src/models/actions/opsRequest.ts` — champ ajouté au schéma zod
- `src/components/Service/OpsRequestForm.tsx` — rendu des champs `select` en RadioButtons