### PR TITLE
fix: hide obsolete matomo/sentry account info

### DIFF
--- a/src/components/MemberPage/MemberStatus.tsx
+++ b/src/components/MemberPage/MemberStatus.tsx
@@ -316,9 +316,9 @@ export const MemberStatus = ({
       </div>,
     ],
     // Matomo account status
-    MatomoInfoRow(matomoInfo, isCurrentUser),
+    //MatomoInfoRow(matomoInfo, isCurrentUser),
     // Sentry account status
-    sentryInfoRow(sentryInfo),
+    //sentryInfoRow(sentryInfo),
   ].filter((z) => !!z);
 
   return (


### PR DESCRIPTION
remove legacy sentry account creation links