### PR TITLE
feat: réserve la validation de l'atelier d'embarquement à l'animation

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -25,6 +25,7 @@ HASH_SALT=SecretThatShouldChangedInProduction
 SECRETARIAT_DOMAIN=betagouv.ovh # domaine à utiliser
 
 ESPACE_MEMBRE_ADMIN=lucas.charrier,julien.dauphant
+ESPACE_MEMBRE_ANIMATION=lucas.charrier,julien.dauphant
 
 # infos connexion API DIMAIL
 DIMAIL_API_URL=xxx

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ utiles du projet.
 
 copier [`.env.development`](./.env.development) en `.env`
 
+Deux variables donnent des droits particuliers. Chacune est une liste de
+`username` (`prenom.nom`) séparés par des virgules :
+
+- `ESPACE_MEMBRE_ADMIN` : administrateurs de l'espace membre.
+- `ESPACE_MEMBRE_ANIMATION` : équipe d'animation. Seule habilitée, avec les
+  administrateurs, à cocher les items de checklist réservés (cf.
+  [`restrictedChecklistItems.ts`](./src/utils/checklists/restrictedChecklistItems.ts)),
+  par exemple la participation à l'atelier d'embarquement.
+
 ### Lancer en mode développement
 
 Un environnement Docker Compose permet de lancer l'application et ses

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -105,6 +105,21 @@ test("recent member expiring soon only sees offboarding panel, not onboarding", 
   }
 });
 
+test("the atelier onboarding item is not checkable by a member", async ({
+  page,
+}) => {
+  // valid.member ne fait pas partie de ESPACE_MEMBRE_ANIMATION : la case
+  // attestant la participation à l'embarquement doit lui être inaccessible.
+  await page.goto("/account?tab=embarquement");
+  await page.waitForURL(/\/account/);
+  await expect(page.getByText("Bienvenue dans la communauté")).toBeVisible();
+
+  const activePanel = page.locator(".fr-tabs__panel--selected");
+  await expect(
+    activePanel.locator('input[value="onboarding-atelier-onboarding"]'),
+  ).toBeDisabled();
+});
+
 test("checking an onboarding item increases the progress bar on account and dashboard", async ({
   page,
 }) => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "migrate": "NODE_OPTIONS='--import tsx/esm' knex migrate:latest",
     "rolldown": "NODE_OPTIONS='--import tsx/esm' knex migrate:down",
     "e2e": "npx playwright test",
-    "test": "NODE_ENV=test ts-mocha --paths -p tsconfig.json src/**/*.spec.ts __tests__/*.ts --exit --require ts-node/register --require ts-node/esm --icu-data-dir=./node_modules/full-icu --require ./__tests__/env-setup.ts --timeout 30000",
+    "test": "NODE_ENV=test ts-mocha --paths -p tsconfig.json src/**/*.spec.ts src/app/api/member/actions/updateUserEvent.spec.ts src/utils/checklists/computeProgress.spec.ts src/utils/checklists/restrictedChecklistItems.spec.ts __tests__/*.ts --exit --require ts-node/register --require ts-node/esm --icu-data-dir=./node_modules/full-icu --require ./__tests__/env-setup.ts --timeout 30000",
     "seed": "NODE_OPTIONS='--import tsx/esm' knex seed:run",
     "postinstall": "is-ci || husky install",
     "kysely-codegen": "./node_modules/.bin/kysely-codegen --include-pattern=\"(public|pgboss).*\" --out-file ./src/@types/db.d.ts",

--- a/src/app/(private)/(dashboard)/account/page.tsx
+++ b/src/app/(private)/(dashboard)/account/page.tsx
@@ -7,6 +7,7 @@ import { userInfos } from "@/server/controllers/utils";
 import { authOptions } from "@/utils/authoptions";
 import { routeTitles } from "@/utils/routes/routeTitles";
 import { getUserIncubators } from "@/lib/kysely/queries/users";
+import { canValidateRestrictedChecklistItem } from "@/lib/canValidateRestrictedChecklistItem";
 import { getUserChecklists } from "@/utils/checklists/getUserChecklists";
 import MemberPage from "@/components/MemberPage/MemberPage";
 
@@ -55,6 +56,9 @@ export default async function Page() {
       startups={userInformations.startups}
       canEditMember={true}
       canValidateMember={false}
+      canValidateRestrictedItems={canValidateRestrictedChecklistItem(
+        session.user.id,
+      )}
       isCurrentUser={true}
       onboarding={onboarding}
       offboarding={offboarding}

--- a/src/app/(private)/(dashboard)/community/[id]/page.tsx
+++ b/src/app/(private)/(dashboard)/community/[id]/page.tsx
@@ -9,6 +9,7 @@ import { userInfos } from "@/server/controllers/utils";
 import { authOptions } from "@/utils/authoptions";
 import { getUserIncubators } from "@/lib/kysely/queries/users";
 import { canEditMember as _canEditMember } from "@/lib/canEditMember";
+import { canValidateRestrictedChecklistItem } from "@/lib/canValidateRestrictedChecklistItem";
 import { getUserChecklists } from "@/utils/checklists/getUserChecklists";
 
 type Props = {
@@ -91,6 +92,9 @@ export default async function Page({
         isCurrentUser={isCurrentUser}
         canEditMember={canEditMember}
         canValidateMember={canValidateMember}
+        canValidateRestrictedItems={canValidateRestrictedChecklistItem(
+          session.user.id,
+        )}
         authorizations={user.authorizations}
         emailInfos={user.emailInfos}
         emailRedirections={user.emailRedirections}

--- a/src/app/api/member/actions/updateUserEvent.spec.ts
+++ b/src/app/api/member/actions/updateUserEvent.spec.ts
@@ -6,7 +6,8 @@ import sinon from "sinon";
 import { updateUserEvent } from "./updateUserEvent";
 import { Users } from "@/@types/db";
 import { db } from "@/lib/kysely";
-import { AuthorizationError } from "@/utils/error";
+import { AuthorizationError, BusinessError } from "@/utils/error";
+import { RESTRICTED_CHECKLIST_ITEM_IDS } from "@/utils/checklists/restrictedChecklistItems";
 import { createData, deleteData } from "__tests__/utils/fakeData";
 import {
   memberJulienD,
@@ -14,12 +15,19 @@ import {
   testUsers,
 } from "__tests__/utils/users-data";
 
+// Un item de checklist ordinaire, auto-déclaratif.
+const FIELD_ID = "onboarding-valeurs-beta";
+// L'item réservé à l'équipe d'animation.
+const RESTRICTED_FIELD_ID = RESTRICTED_CHECKLIST_ITEM_IDS[0];
+
 describe("Update user event server action", () => {
   let getServerSessionStub, updateUserEventHandler: typeof updateUserEvent;
+  let canValidateRestrictedStub: sinon.SinonStub;
   let user: Selectable<Users>;
 
   beforeEach(async () => {
     getServerSessionStub = sinon.stub();
+    canValidateRestrictedStub = sinon.stub().returns(false);
     await createData(testUsers);
 
     // Use proxyquire to replace bossClient module
@@ -28,6 +36,10 @@ describe("Update user event server action", () => {
       {
         "next-auth/next": { getServerSession: getServerSessionStub },
         "next/cache": { revalidatePath: sinon.stub().resolves() },
+        "@/lib/canValidateRestrictedChecklistItem": {
+          canValidateRestrictedChecklistItem: canValidateRestrictedStub,
+          "@noCallThru": true,
+        },
       },
     ).updateUserEvent as typeof updateUserEvent;
     user = await db
@@ -54,7 +66,7 @@ describe("Update user event server action", () => {
     await updateUserEventHandler({
       value: true,
       action_on_user_id: user.uuid,
-      field_id: "a-field-id",
+      field_id: FIELD_ID,
     });
   });
   it("should delete event if it exist if value is true", async () => {
@@ -71,14 +83,14 @@ describe("Update user event server action", () => {
       .values({
         user_id: user.uuid,
         date: new Date(),
-        field_id: "a-field-id",
+        field_id: FIELD_ID,
       })
       .returningAll()
       .executeTakeFirstOrThrow();
     await updateUserEventHandler({
       value: false,
       action_on_user_id: user.uuid,
-      field_id: "a-field-id",
+      field_id: FIELD_ID,
     });
     const event = await db
       .selectFrom("user_events")
@@ -104,12 +116,12 @@ describe("Update user event server action", () => {
     await updateUserEventHandler({
       value: true,
       action_on_user_id: otherUser.uuid,
-      field_id: "a-field-id",
+      field_id: FIELD_ID,
     });
     const event = await db
       .selectFrom("user_events")
       .where("user_id", "=", otherUser.uuid)
-      .where("field_id", "=", "a-field-id")
+      .where("field_id", "=", FIELD_ID)
       .executeTakeFirstOrThrow();
     event.should.be.exist;
   });
@@ -129,14 +141,14 @@ describe("Update user event server action", () => {
       .values({
         user_id: user.uuid,
         date: new Date(),
-        field_id: "a-field-id",
+        field_id: FIELD_ID,
       })
       .returningAll()
       .executeTakeFirstOrThrow();
     await updateUserEventHandler({
       value: true,
       action_on_user_id: user.uuid,
-      field_id: "a-field-id",
+      field_id: FIELD_ID,
       date: today,
     });
     const event = await db
@@ -167,7 +179,7 @@ describe("Update user event server action", () => {
       .values({
         user_id: otherUser.uuid,
         date: new Date(),
-        field_id: "a-field-id",
+        field_id: FIELD_ID,
       })
       .returningAll()
       .executeTakeFirstOrThrow();
@@ -175,7 +187,7 @@ describe("Update user event server action", () => {
     await updateUserEventHandler({
       value: false,
       action_on_user_id: otherUser.uuid,
-      field_id: "a-field-id",
+      field_id: FIELD_ID,
     });
     const event = await db
       .selectFrom("user_events")
@@ -195,7 +207,7 @@ describe("Update user event server action", () => {
       .values({
         user_id: otherUser.uuid,
         date: new Date(),
-        field_id: "a-field-id",
+        field_id: FIELD_ID,
       })
       .returningAll()
       .executeTakeFirstOrThrow();
@@ -213,7 +225,7 @@ describe("Update user event server action", () => {
       await updateUserEventHandler({
         value: false,
         action_on_user_id: otherUser.uuid,
-        field_id: "a-field-id",
+        field_id: FIELD_ID,
       });
     } catch (e) {
       thrown = e;
@@ -248,7 +260,7 @@ describe("Update user event server action", () => {
       await updateUserEventHandler({
         value: true,
         action_on_user_id: otherUser.uuid,
-        field_id: "a-field-id",
+        field_id: FIELD_ID,
       });
     } catch (e) {
       thrown = e;
@@ -259,7 +271,7 @@ describe("Update user event server action", () => {
     const event = await db
       .selectFrom("user_events")
       .where("user_id", "=", otherUser.uuid)
-      .where("field_id", "=", "a-field-id")
+      .where("field_id", "=", FIELD_ID)
       .executeTakeFirst();
     expect(event).to.be.undefined;
   });
@@ -272,7 +284,163 @@ describe("Update user event server action", () => {
       await updateUserEventHandler({
         value: true,
         action_on_user_id: user.uuid,
+        field_id: FIELD_ID,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+  });
+
+  it("should throw BusinessError when the field_id is not a real checklist item", async () => {
+    getServerSessionStub.resolves({
+      user: { id: membreActif.username, isAdmin: false, uuid: user.uuid },
+    });
+
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: true,
+        action_on_user_id: user.uuid,
         field_id: "a-field-id",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(BusinessError);
+
+    const event = await db
+      .selectFrom("user_events")
+      .where("user_id", "=", user.uuid)
+      .where("field_id", "=", "a-field-id")
+      .executeTakeFirst();
+    expect(event).to.be.undefined;
+  });
+
+  it("should throw BusinessError when the field_id is a disabled checklist item", async () => {
+    // onboarding-fiche-membre est `disabled` + `defaultValue` : il est deja
+    // compte par l'offset de computeProgress, une ligne en base le compterait
+    // une seconde fois et permettrait d'atteindre 100% sans l'atelier.
+    getServerSessionStub.resolves({
+      user: { id: membreActif.username, isAdmin: false, uuid: user.uuid },
+    });
+
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: true,
+        action_on_user_id: user.uuid,
+        field_id: "onboarding-fiche-membre",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(BusinessError);
+  });
+
+  it("should throw AuthorizationError when a member checks a restricted item on themselves", async () => {
+    canValidateRestrictedStub.returns(false);
+    getServerSessionStub.resolves({
+      user: { id: membreActif.username, isAdmin: false, uuid: user.uuid },
+    });
+
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: true,
+        action_on_user_id: user.uuid,
+        field_id: RESTRICTED_FIELD_ID,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+
+    const event = await db
+      .selectFrom("user_events")
+      .where("user_id", "=", user.uuid)
+      .where("field_id", "=", RESTRICTED_FIELD_ID)
+      .executeTakeFirst();
+    expect(event).to.be.undefined;
+  });
+
+  it("should throw AuthorizationError when a member unchecks a restricted item on themselves", async () => {
+    canValidateRestrictedStub.returns(false);
+    const userEvent = await db
+      .insertInto("user_events")
+      .values({
+        user_id: user.uuid,
+        date: new Date(),
+        field_id: RESTRICTED_FIELD_ID,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    getServerSessionStub.resolves({
+      user: { id: membreActif.username, isAdmin: false, uuid: user.uuid },
+    });
+
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: false,
+        action_on_user_id: user.uuid,
+        field_id: RESTRICTED_FIELD_ID,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.instanceOf(AuthorizationError);
+
+    // L'evenement ne doit PAS avoir ete supprime.
+    const event = await db
+      .selectFrom("user_events")
+      .where("uuid", "=", userEvent.uuid)
+      .executeTakeFirst();
+    expect(event).to.not.be.undefined;
+  });
+
+  it("should let the animation team check a restricted item for a member it cannot otherwise edit", async () => {
+    canValidateRestrictedStub.returns(true);
+    getServerSessionStub.resolves({
+      user: { id: membreActif.username, isAdmin: false, uuid: user.uuid },
+    });
+    const otherUser = await db
+      .selectFrom("users")
+      .selectAll()
+      .where("username", "=", memberJulienD.username)
+      .executeTakeFirstOrThrow();
+
+    await updateUserEventHandler({
+      value: true,
+      action_on_user_id: otherUser.uuid,
+      field_id: RESTRICTED_FIELD_ID,
+    });
+
+    const event = await db
+      .selectFrom("user_events")
+      .where("user_id", "=", otherUser.uuid)
+      .where("field_id", "=", RESTRICTED_FIELD_ID)
+      .executeTakeFirst();
+    expect(event).to.not.be.undefined;
+  });
+
+  it("should not let the animation team edit a non restricted item of a member it cannot edit", async () => {
+    canValidateRestrictedStub.returns(true);
+    getServerSessionStub.resolves({
+      user: { id: membreActif.username, isAdmin: false, uuid: user.uuid },
+    });
+    const otherUser = await db
+      .selectFrom("users")
+      .selectAll()
+      .where("username", "=", memberJulienD.username)
+      .executeTakeFirstOrThrow();
+
+    let thrown: unknown;
+    try {
+      await updateUserEventHandler({
+        value: true,
+        action_on_user_id: otherUser.uuid,
+        field_id: FIELD_ID,
       });
     } catch (e) {
       thrown = e;

--- a/src/app/api/member/actions/updateUserEvent.ts
+++ b/src/app/api/member/actions/updateUserEvent.ts
@@ -2,12 +2,16 @@
 
 import { revalidatePath } from "next/cache";
 import { getServerSession } from "next-auth/next";
+import { z } from "zod";
 
 import { canEditMember } from "@/lib/canEditMember";
+import { canValidateRestrictedChecklistItem } from "@/lib/canValidateRestrictedChecklistItem";
 import { addEvent } from "@/lib/events";
 import { db } from "@/lib/kysely";
 import { getUserInfos } from "@/lib/kysely/queries/users";
 import { EventCode } from "@/models/actionEvent/actionEvent";
+import { getChecklistObject } from "@/utils/checklists/getChecklistObject";
+import { isRestrictedChecklistItem } from "@/utils/checklists/restrictedChecklistItems";
 import { authOptions } from "@/utils/authoptions";
 import {
   AuthorizationError,
@@ -16,12 +20,46 @@ import {
   withErrorHandling,
 } from "@/utils/error";
 
-export async function updateUserEvent({
-  action_on_user_id,
-  field_id,
-  value,
-  date,
-}: {
+const updateUserEventSchema = z.object({
+  action_on_user_id: z.string().uuid().optional(),
+  field_id: z.string().min(1),
+  value: z.boolean(),
+  date: z.coerce.date().optional(),
+});
+
+/**
+ * Ids de checklist réellement inscriptibles : ceux des yml, moins les items
+ * `disabled` qui ne doivent jamais atterrir en base (computeProgress les compte
+ * déjà via son `offset`, une ligne user_events les compterait une seconde fois).
+ *
+ * Fail-closed : si un yml ne parse pas, getChecklistObject renvoie null après
+ * avoir notifié Sentry, et on refuse l'écriture plutôt que de tout accepter.
+ */
+async function getWritableChecklistItemIds(): Promise<Set<string>> {
+  const checklists = await Promise.all([
+    getChecklistObject("onboarding"),
+    getChecklistObject("offboarding"),
+  ]);
+  const ids = new Set<string>();
+  for (const checklist of checklists) {
+    if (!checklist) {
+      throw new BusinessError(
+        "ChecklistUnavailable",
+        "La checklist est indisponible, l'enregistrement est impossible.",
+      );
+    }
+    for (const section of checklist) {
+      for (const item of section.items) {
+        if (!item.disabled) {
+          ids.add(item.id);
+        }
+      }
+    }
+  }
+  return ids;
+}
+
+export async function updateUserEvent(params: {
   action_on_user_id?: string;
   field_id: string;
   value: boolean;
@@ -31,14 +69,45 @@ export async function updateUserEvent({
   if (!session || !session.user?.uuid) {
     throw new AuthorizationError();
   }
+
+  const { action_on_user_id, field_id, value, date } =
+    updateUserEventSchema.parse(params);
+
+  // Le field_id doit correspondre à un item de checklist existant : sans ça
+  // n'importe quel membre peut écrire des lignes user_events arbitraires.
+  const writableFieldIds = await getWritableChecklistItemIds();
+  if (!writableFieldIds.has(field_id)) {
+    throw new BusinessError(
+      "UnknownChecklistItem",
+      "Cet item de checklist n'existe pas.",
+    );
+  }
+
   const user_id = action_on_user_id || session.user.uuid;
+  const isSelfEdit = session.user.uuid === user_id;
+  const isRestrictedField = isRestrictedChecklistItem(field_id);
+  // Relecture de la configuration serveur : jamais un booléen venant du client.
+  const canValidateRestricted = canValidateRestrictedChecklistItem(
+    session.user.id,
+  );
+
+  // Un item réservé n'est ni cochable ni décochable par quelqu'un d'autre que
+  // l'équipe d'animation, y compris sur son propre compte.
+  if (isRestrictedField && !canValidateRestricted) {
+    throw new AuthorizationError(
+      "Seule l'équipe d'animation peut valider la participation à l'embarquement.",
+    );
+  }
 
   // Defense in depth: only allow editing one's own user events, unless the
   // session user has edit permissions on the target member (admin, same
   // incubator team, or shared startup with contractuel/fonctionnaire status).
-  const isSelfEdit = session.user.uuid === user_id;
+  // Exception : l'embarquement est un rituel transverse, l'équipe d'animation
+  // doit pouvoir l'attester pour n'importe quel membre. L'exception est
+  // strictement limitée aux items réservés.
   if (
     !isSelfEdit &&
+    !(isRestrictedField && canValidateRestricted) &&
     !(await canEditMember({ memberUuid: user_id, sessionUser: session.user }))
   ) {
     throw new AuthorizationError();

--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -6,6 +6,7 @@ import MarkdownIt from "markdown-it";
 import { safeUpdateUserEvent } from "@/app/api/member/actions/updateUserEvent";
 import { Domaine } from "@/models/member";
 import { checklistSchemaType } from "@/models/checklist";
+import { isRestrictedChecklistItem } from "@/utils/checklists/restrictedChecklistItems";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 
 const mdParser = new MarkdownIt({
@@ -18,6 +19,9 @@ mdParser.renderer.rules.link_open = function (tokens, idx, options, env, self) {
   return self.renderToken(tokens, idx, options);
 };
 
+const RESTRICTED_ITEM_HINT =
+  "Cette case est cochée par l'équipe d'animation, après la participation à l'embarquement.";
+
 export default function Checklist({
   domaine,
   sections,
@@ -25,6 +29,7 @@ export default function Checklist({
   handleUserEventIdsChange,
   userUuid,
   readOnly,
+  canValidateRestrictedItems = false,
 }: {
   domaine: Domaine;
   sections: checklistSchemaType;
@@ -32,13 +37,21 @@ export default function Checklist({
   handleUserEventIdsChange: (eventIds: string[]) => void;
   userUuid: string;
   readOnly: boolean;
+  canValidateRestrictedItems?: boolean;
 }) {
+  const [error, setError] = useState<{
+    sectionIndex: number;
+    message: string;
+  } | null>(null);
   const isVisible = (domaines?: string[]) => {
     if (!domaines) return true;
     return domaines.includes(domaine);
   };
-  const onChange = async (e, field_id) => {
-    const value = e.target.checked;
+  const onChange = async (e, field_id, sectionIndex) => {
+    const input = e.target as HTMLInputElement;
+    const value = input.checked;
+    const previousUserEventIds = userEventIds;
+    setError(null);
     if (userEventIds.includes(field_id) && !value) {
       handleUserEventIdsChange(
         userEventIds.filter((userEventId) => userEventId !== field_id),
@@ -52,7 +65,12 @@ export default function Checklist({
       value,
     });
     if (!res.success) {
+      // Rien n'a été enregistré : on remet la case et la progression dans leur
+      // état précédent, sinon l'utilisateur croit que c'est pris en compte.
       console.error("ERROR", res.message);
+      handleUserEventIdsChange(previousUserEventIds);
+      input.checked = !value;
+      setError({ sectionIndex, message: res.message });
     }
   };
 
@@ -69,23 +87,36 @@ export default function Checklist({
             defaultExpanded={expand}
           >
             <Checkbox
-              options={section.items.map((item, index) => ({
-                label: (
-                  <span
-                    dangerouslySetInnerHTML={{
-                      __html: mdParser.renderInline(item.title),
-                    }}
-                  />
-                ),
-                nativeInputProps: {
-                  name: `checkboxes-${index}`,
-                  value: item.id,
-                  disabled: item.disabled || readOnly,
-                  defaultChecked:
-                    item.defaultValue || userEventIds.includes(item.id),
-                  onChange: (e) => onChange(e, item.id),
-                },
-              }))}
+              state={error?.sectionIndex === i ? "error" : "default"}
+              stateRelatedMessage={
+                error?.sectionIndex === i ? error.message : undefined
+              }
+              options={section.items.map((item, index) => {
+                const isRestricted = isRestrictedChecklistItem(item.id);
+                return {
+                  label: (
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: mdParser.renderInline(item.title),
+                      }}
+                    />
+                  ),
+                  hintText: isRestricted ? RESTRICTED_ITEM_HINT : undefined,
+                  nativeInputProps: {
+                    name: `checkboxes-${index}`,
+                    value: item.id,
+                    // Un item réservé échappe à readOnly : l'équipe d'animation
+                    // doit pouvoir l'attester y compris sur la fiche d'un membre
+                    // qu'elle n'a pas le droit d'éditer par ailleurs.
+                    disabled:
+                      item.disabled ||
+                      (isRestricted ? !canValidateRestrictedItems : readOnly),
+                    defaultChecked:
+                      item.defaultValue || userEventIds.includes(item.id),
+                    onChange: (e) => onChange(e, item.id, i),
+                  },
+                };
+              })}
             />
           </Accordion>
         );

--- a/src/components/MemberPage/CheckListTabPanel.tsx
+++ b/src/components/MemberPage/CheckListTabPanel.tsx
@@ -15,6 +15,7 @@ export const ChecklistTabPanel = ({
   checklistObject,
   intro,
   readOnly,
+  canValidateRestrictedItems = false,
   offset = 0,
 }: {
   userEvents: userEventSchemaType[];
@@ -22,6 +23,7 @@ export const ChecklistTabPanel = ({
   userInfos: memberWrapperSchemaType["userInfos"];
   intro: ReactNode;
   readOnly: boolean;
+  canValidateRestrictedItems?: boolean;
   offset?: number;
 }) => {
   const [userEventIds, setUserEventIds] = useState<string[]>(
@@ -42,6 +44,7 @@ export const ChecklistTabPanel = ({
       />
       <Checklist
         readOnly={readOnly}
+        canValidateRestrictedItems={canValidateRestrictedItems}
         userUuid={userInfos.uuid}
         userEventIds={userEventIds}
         handleUserEventIdsChange={setUserEventIds}

--- a/src/components/MemberPage/MemberPage.tsx
+++ b/src/components/MemberPage/MemberPage.tsx
@@ -55,6 +55,7 @@ export interface MemberPageProps {
   startups: Awaited<ReturnType<typeof getUserStartups>>;
   canEditMember: boolean;
   canValidateMember: boolean;
+  canValidateRestrictedItems?: boolean;
   isAdmin: boolean;
   isCurrentUser: boolean;
   onboarding?: UserChecklist;
@@ -73,6 +74,7 @@ export default function MemberPage({
   changes,
   canEditMember,
   canValidateMember,
+  canValidateRestrictedItems = false,
   isAdmin,
   avatar,
   isCurrentUser,
@@ -175,6 +177,7 @@ export default function MemberPage({
         <ChecklistTabPanel
           offset={1}
           readOnly={!canEditMember}
+          canValidateRestrictedItems={canValidateRestrictedItems}
           userEvents={onboarding.userEvents}
           userInfos={userInfos}
           checklistObject={onboarding.checklistObject}
@@ -194,6 +197,7 @@ export default function MemberPage({
       content: (
         <ChecklistTabPanel
           readOnly={!canEditMember}
+          canValidateRestrictedItems={canValidateRestrictedItems}
           userEvents={offboarding.userEvents}
           userInfos={userInfos}
           checklistObject={offboarding.checklistObject}

--- a/src/lib/canValidateRestrictedChecklistItem.spec.ts
+++ b/src/lib/canValidateRestrictedChecklistItem.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import proxyquire from "proxyquire";
+
+import { canValidateRestrictedChecklistItem as realFn } from "./canValidateRestrictedChecklistItem";
+
+const load = (admins: string[], animation: string[]): typeof realFn =>
+  proxyquire("@/lib/canValidateRestrictedChecklistItem", {
+    "@/server/config/admin.config": {
+      getAdmin: () => admins,
+      "@noCallThru": true,
+    },
+    "@/server/config/animation.config": {
+      getAnimation: () => animation,
+      "@noCallThru": true,
+    },
+  }).canValidateRestrictedChecklistItem;
+
+describe("canValidateRestrictedChecklistItem", () => {
+  it("should allow a member of the animation team", () => {
+    const fn = load([], ["jean.dupont"]);
+    expect(fn("jean.dupont")).to.be.true;
+  });
+
+  it("should allow an admin even when not in the animation team", () => {
+    const fn = load(["jean.dupont"], []);
+    expect(fn("jean.dupont")).to.be.true;
+  });
+
+  it("should refuse a member in neither list", () => {
+    const fn = load(["jean.dupont"], ["marie.martin"]);
+    expect(fn("pierre.durand")).to.be.false;
+  });
+
+  it("should refuse when the username is missing", () => {
+    const fn = load(["jean.dupont"], ["marie.martin"]);
+    expect(fn(undefined)).to.be.false;
+    expect(fn(null)).to.be.false;
+    expect(fn("")).to.be.false;
+  });
+});

--- a/src/lib/canValidateRestrictedChecklistItem.ts
+++ b/src/lib/canValidateRestrictedChecklistItem.ts
@@ -1,0 +1,19 @@
+import { getAdmin } from "@/server/config/admin.config";
+import { getAnimation } from "@/server/config/animation.config";
+
+/**
+ * Droit de cocher/décocher un item de checklist réservé, cf.
+ * src/utils/checklists/restrictedChecklistItems.ts.
+ *
+ * Lit les listes serveur issues de l'environnement. Ne jamais se baser sur un
+ * booléen porté par la session ou par le client pour autoriser l'écriture.
+ *
+ * @param username session.user.id, c'est à dire users.username : c'est la clé
+ * sur laquelle ESPACE_MEMBRE_ADMIN et ESPACE_MEMBRE_ANIMATION sont indexés.
+ */
+export const canValidateRestrictedChecklistItem = (
+  username?: string | null,
+): boolean => {
+  if (!username) return false;
+  return getAdmin().includes(username) || getAnimation().includes(username);
+};

--- a/src/server/config/animation.config.ts
+++ b/src/server/config/animation.config.ts
@@ -1,0 +1,5 @@
+import config from ".";
+
+export const getAnimation = () => {
+  return [...config.ESPACE_MEMBRE_ANIMATION];
+};

--- a/src/server/config/index.ts
+++ b/src/server/config/index.ts
@@ -127,6 +127,12 @@ export default {
   ESPACE_MEMBRE_ADMIN: process.env.ESPACE_MEMBRE_ADMIN
     ? process.env.ESPACE_MEMBRE_ADMIN.split(",")
     : [],
+  // Membres de l'équipe animation, autorisés à valider les items de checklist
+  // réservés (cf. src/utils/checklists/restrictedChecklistItems.ts).
+  ESPACE_MEMBRE_ANIMATION: (process.env.ESPACE_MEMBRE_ANIMATION ?? "")
+    .split(",")
+    .map((username) => username.trim())
+    .filter(Boolean),
   MAILING_LIST_NEWSLETTER: parseInt(getOrThrowError("MAILING_LIST_NEWSLETTER")),
   MAILING_LIST_ONBOARDING: process.env.MAILING_LIST_ONBOARDING
     ? parseInt(process.env.MAILING_LIST_ONBOARDING)

--- a/src/utils/checklists/restrictedChecklistItems.spec.ts
+++ b/src/utils/checklists/restrictedChecklistItems.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+
+import { getChecklistObject } from "./getChecklistObject";
+import { RESTRICTED_CHECKLIST_ITEM_IDS } from "./restrictedChecklistItems";
+
+describe("restrictedChecklistItems", () => {
+  // Garde-fou : renommer un id dans onboarding.yml sans toucher à la constante
+  // désactiverait la protection en silence.
+  it("should only reference ids that exist in the checklists", async () => {
+    const checklists = await Promise.all([
+      getChecklistObject("onboarding"),
+      getChecklistObject("offboarding"),
+    ]);
+    const existingIds = checklists.flatMap((checklist) =>
+      (checklist ?? []).flatMap((section) => section.items.map((i) => i.id)),
+    );
+    for (const id of RESTRICTED_CHECKLIST_ITEM_IDS) {
+      expect(existingIds).to.include(id);
+    }
+  });
+
+  it("should not reference items disabled in the yml, which are never writable", async () => {
+    const checklist = (await getChecklistObject("onboarding")) ?? [];
+    const disabledIds = checklist.flatMap((section) =>
+      section.items.filter((i) => i.disabled).map((i) => i.id),
+    );
+    for (const id of RESTRICTED_CHECKLIST_ITEM_IDS) {
+      expect(disabledIds).to.not.include(id);
+    }
+  });
+});

--- a/src/utils/checklists/restrictedChecklistItems.ts
+++ b/src/utils/checklists/restrictedChecklistItems.ts
@@ -1,0 +1,18 @@
+/**
+ * Items de checklist qui ne sont pas auto-déclaratifs : seule l'équipe
+ * d'animation (ou un admin) peut les cocher/décocher, pour attester d'une
+ * participation.
+ *
+ * Volontairement défini en TypeScript et non dans les fichiers yml : le yml est
+ * lu par getChecklistObject() qui renvoie `null` quand le parse échoue, ce qui
+ * ferait sauter la protection en silence.
+ *
+ * Ce module est importé côté client (Checklist.tsx) autant que côté serveur : il
+ * ne doit contenir aucun import de configuration serveur.
+ */
+export const RESTRICTED_CHECKLIST_ITEM_IDS = [
+  "onboarding-atelier-onboarding",
+] as const;
+
+export const isRestrictedChecklistItem = (fieldId: string): boolean =>
+  (RESTRICTED_CHECKLIST_ITEM_IDS as readonly string[]).includes(fieldId);


### PR DESCRIPTION
Ref betagouv/beta-botAdmin#39 (à fermer à la main, les mots-clés ne traversent pas les repos).

`onboarding-atelier-onboarding` était auto-déclaratif : n'importe quel membre pouvait attester sa propre participation. Réservé à l'équipe animation.

## Ce que ça fait

- **Membre** : case grisée, avec un hint expliquant que l'animation la coche. Ni cochable ni décochable, y compris sur sa propre fiche.
- **Animation** : coche depuis `/community/<username>`, onglet Embarquement, pour n'importe quel membre même hors de son incubateur — l'embarquement est transverse. Exception strictement limitée aux items réservés : aucun droit gagné sur le reste de la checklist.
- **Droit** : nouvelle env var `ESPACE_MEMBRE_ANIMATION` (usernames séparés par des virgules, calquée sur `ESPACE_MEMBRE_ADMIN`). Admins autorisés aussi.

Pas réutilisé `isAdmin` seul : il ouvre `admin-update`, les routes events/Brevo, `/api/image`, ops. Trop large pour cocher une case.

## Garde serveur

Dans `updateUserEvent`, avant toute écriture, donc le DELETE est couvert autant que l'UPSERT. Relit la config serveur, ne fait jamais confiance à un booléen client.

Côté UI, `disabled` dépend du visiteur et **lève** `readOnly` pour les items réservés — sinon l'animation serait bloquée sur la fiche d'un membre qu'elle n'a pas le droit d'éditer, et la garde serveur serait du code mort.

## Bug corrigé au passage

`field_id` n'était pas validé. `computeProgress` ajoute un `offset` de 1 pour `onboarding-fiche-membre`, jamais écrit en base. En appelant l'action avec ce `field_id`, un membre le faisait compter deux fois et atteignait 100 % sans l'atelier — la restriction aurait été cosmétique. `field_id` est maintenant validé contre les items réels, hors items `disabled`, fail-closed.

## Tests

`79 passing, 0 failing`. 6 nouveaux cas sur l'action (cochage refusé, **décochage refusé**, animation sur un membre non éditable, admin, field_id inconnu, field_id `disabled`), 4 sur le helper, 2 anti-dérive constante/yml, 1 e2e.

Les specs de `updateUserEvent` ne tournaient pas : le glob `src/**/*.spec.ts` du script `test` est interprété par `sh`, qui ne descend que d'un niveau — les tests de sécurité existants de cette action n'ont jamais tourné en CI. Chemins ajoutés explicitement. Le vrai fix du glob réveille 12 specs dormants en échec (`sync-matrix-accounts`, `recreateEmailIfUserActive`, dimail) → ticket séparé.

`tsc` : 42 erreurs avant, 42 après, aucune nouvelle (la baseline `main` est déjà rouge).

## Vérifié à la main

En local, membre non-animation : case grisée. Membre dans `ESPACE_MEMBRE_ANIMATION` et **non admin** : coche sur la fiche d'un membre sans startup commune, ligne écrite en base, audit `MEMBER_UPDATE_USER_EVENTS` correct, persiste après reload.

## ⚠️ Au déploiement

Renseigner `ESPACE_MEMBRE_ANIMATION` à la main dans Scalingo (`scalingo.json` ne contient que des valeurs générées). Sans ça, liste vide et personne hors admins ne peut valider.

## Choix assumés

- Les cases déjà auto-déclarées sont conservées : pour cet historique, « cochée » ≠ « attestée ». Une purge serait destructive.
- Un membre sans l'atelier plafonne à 29/30 et garde l'encart d'embarquement sur son dashboard. Cohérent, mais peut générer des « mon dashboard est bloqué ».
- `onboarding-forum-beta` (« journée d'embarquement obligatoire ») reste auto-déclaratif : hors périmètre de l'issue. La constante est un tableau, une ligne à ajouter.
- Un membre de l'animation peut auto-valider sa propre case, comme un admin.
- `disabled` retire la case du parcours clavier : les lecteurs d'écran ne rencontrent ni l'item ni son explication. `aria-disabled` serait mieux, coût non nul, à arbitrer.